### PR TITLE
Fix: Pod IP addresses were not in correct IP range.

### DIFF
--- a/cluster/photon-controller/util.sh
+++ b/cluster/photon-controller/util.sh
@@ -422,7 +422,7 @@ function gen-node-salt {
             echo "salt ${NODE_NAMES[$i]} state.highstate -t 30 --no-color > /tmp/${NODE_NAMES[$i]}-salt.out"
             echo "grep -E \"Failed:[[:space:]]+0\" /tmp/${NODE_NAMES[$i]}-salt.out"
             echo 'success=$?'
-            echo "cat /tmp/master.out >> /tmp/${NODE_NAMES[$i]}-salt.log"
+            echo "cat /tmp/${NODE_NAMES[$i]}-salt.out >> /tmp/${NODE_NAMES[$i]}-salt.log"
             echo 'exit $success'
         ) > "${KUBE_TEMP}/${NODE_NAMES[$i]}-salt.sh"
     done

--- a/cluster/saltbase/salt/docker/init.sls
+++ b/cluster/saltbase/salt/docker/init.sls
@@ -69,6 +69,7 @@ docker:
         environment_file: {{ environment_file }}
     - require:
       - file: /opt/kubernetes/helpers/docker-prestart
+      - pkg: docker-engine
 
 # The docker service.running block below doesn't work reliably
 # Instead we run our script which e.g. does a systemd daemon-reload
@@ -144,6 +145,7 @@ docker-engine:
      - version: 1.9.*
      - require:
        - file: /etc/apt/sources.list.d/docker.list
+
 docker:
    service.running:
      - enable: True


### PR DESCRIPTION
Docker didn't start up correctly on the minions because we started
installed our custom docker.service file before docker. Our custom
file was overwritten and not used, and therefore the correct IPs
weren't used.

Debugging this turned up a minor error in how we log during the
installation of salt, so taht was also fixed.