### PR TITLE
Hardening of util.sh and setup-prereqs

### DIFF
--- a/cluster/photon-controller/config-default.sh
+++ b/cluster/photon-controller/config-default.sh
@@ -74,7 +74,8 @@ DNS_DOMAIN="cluster.local"
 DNS_REPLICAS=1
 
 # Optional: Install Kubernetes UI
-ENABLE_CLUSTER_UI="${KUBE_ENABLE_CLUSTER_UI:-true}"
+# This is currently disabled because it's not fully working
+ENABLE_CLUSTER_UI=false
 
 # Optional: if set to true, kube-up will configure the cluster to run e2e tests.
 E2E_STORAGE_TEST_ENVIRONMENT=${KUBE_E2E_STORAGE_TEST_ENVIRONMENT:-false}


### PR DESCRIPTION
* setup-prereqs does a lot more error checking now
* setup-prereqs does not consider an image in ERROR state to be valid
* kube-up verifies more Photon config now
* kube-up doesn't rely on the target tenant or project being set
* kube-up fails if more than one image of the requested name exists
  since it's unclear what we should do.
* Disable dashboard ui since it doesn't currently work for us. (Not
  a dashboard problem, but something in our config.)