### PR TITLE
Differentiate vsphere and photon-controller in salt configuration

### DIFF
--- a/cluster/get-kube.sh
+++ b/cluster/get-kube.sh
@@ -34,6 +34,8 @@
 #   * export KUBERNETES_PROVIDER=vagrant; wget -q -O - https://get.k8s.io | bash
 #  VMWare VSphere
 #   * export KUBERNETES_PROVIDER=vsphere; wget -q -O - https://get.k8s.io | bash
+#  VMWare Photon Controller
+#   * export KUBERNETES_PROVIDER=photon-controller; wget -q -O - https://get.k8s.io | bash
 #  Rackspace
 #   * export KUBERNETES_PROVIDER=rackspace; wget -q -O - https://get.k8s.io | bash
 #

--- a/cluster/kube-env.sh
+++ b/cluster/kube-env.sh
@@ -18,7 +18,7 @@
 # You can override the default provider by exporting the KUBERNETES_PROVIDER
 # variable in your bashrc
 #
-# The valid values: 'gce', 'gke', 'aws', 'vagrant', 'vsphere', 'libvirt-coreos', 'juju'
+# The valid values: 'gce', 'gke', 'aws', 'vagrant', 'vsphere', 'photon-controller', 'libvirt-coreos', 'juju'
 
 KUBERNETES_PROVIDER=${KUBERNETES_PROVIDER:-gce}
 

--- a/cluster/photon-controller/templates/create-dynamic-salt-files.sh
+++ b/cluster/photon-controller/templates/create-dynamic-salt-files.sh
@@ -1,0 +1,129 @@
+#!/bin/bash
+
+# Copyright 2014 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#generate token files
+
+KUBELET_TOKEN=$(dd if=/dev/urandom bs=128 count=1 2>/dev/null | base64 | tr -d "=+/" | dd bs=32 count=1 2>/dev/null)
+KUBE_PROXY_TOKEN=$(dd if=/dev/urandom bs=128 count=1 2>/dev/null | base64 | tr -d "=+/" | dd bs=32 count=1 2>/dev/null)
+known_tokens_file="/srv/salt-overlay/salt/kube-apiserver/known_tokens.csv"
+if [[ ! -f "${known_tokens_file}" ]]; then
+
+  mkdir -p /srv/salt-overlay/salt/kube-apiserver
+  known_tokens_file="/srv/salt-overlay/salt/kube-apiserver/known_tokens.csv"
+  (umask u=rw,go= ;
+   echo "$KUBELET_TOKEN,kubelet,kubelet" > $known_tokens_file;
+   echo "$KUBE_PROXY_TOKEN,kube_proxy,kube_proxy" >> $known_tokens_file)
+
+  mkdir -p /srv/salt-overlay/salt/kubelet
+  kubelet_auth_file="/srv/salt-overlay/salt/kubelet/kubernetes_auth"
+  (umask u=rw,go= ; echo "{\"BearerToken\": \"$KUBELET_TOKEN\", \"Insecure\": true }" > $kubelet_auth_file)
+  kubelet_kubeconfig_file="/srv/salt-overlay/salt/kubelet/kubeconfig"
+
+  mkdir -p /srv/salt-overlay/salt/kubelet
+  (umask 077;
+  cat > "${kubelet_kubeconfig_file}" << EOF
+apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    insecure-skip-tls-verify: true
+  name: local
+contexts:
+- context:
+    cluster: local
+    user: kubelet
+  name: service-account-context
+current-context: service-account-context
+users:
+- name: kubelet
+  user:
+    token: ${KUBELET_TOKEN}
+EOF
+)
+
+
+  mkdir -p /srv/salt-overlay/salt/kube-proxy
+  kube_proxy_kubeconfig_file="/srv/salt-overlay/salt/kube-proxy/kubeconfig"
+  # Make a kubeconfig file with the token.
+  # TODO(etune): put apiserver certs into secret too, and reference from authfile,
+  # so that "Insecure" is not needed.
+  (umask 077;
+  cat > "${kube_proxy_kubeconfig_file}" << EOF
+apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    insecure-skip-tls-verify: true
+  name: local
+contexts:
+- context:
+    cluster: local
+    user: kube-proxy
+  name: service-account-context
+current-context: service-account-context
+users:
+- name: kube-proxy
+  user:
+    token: ${KUBE_PROXY_TOKEN}
+EOF
+)
+
+  # Generate tokens for other "service accounts".  Append to known_tokens.
+  #
+  # NB: If this list ever changes, this script actually has to
+  # change to detect the existence of this file, kill any deleted
+  # old tokens and add any new tokens (to handle the upgrade case).
+  service_accounts=("system:scheduler" "system:controller_manager" "system:logging" "system:monitoring" "system:dns")
+  for account in "${service_accounts[@]}"; do
+    token=$(dd if=/dev/urandom bs=128 count=1 2>/dev/null | base64 | tr -d "=+/" | dd bs=32 count=1 2>/dev/null)
+    echo "${token},${account},${account}" >> "${known_tokens_file}"
+  done
+fi
+
+readonly BASIC_AUTH_FILE="/srv/salt-overlay/salt/kube-apiserver/basic_auth.csv"
+if [ ! -e "${BASIC_AUTH_FILE}" ]; then
+  mkdir -p /srv/salt-overlay/salt/kube-apiserver
+  (umask 077;
+    echo "${KUBE_PASSWORD},${KUBE_USER},admin" > "${BASIC_AUTH_FILE}")
+fi
+
+
+# Create the overlay files for the salt tree.  We create these in a separate
+# place so that we can blow away the rest of the salt configs on a kube-push and
+# re-apply these.
+
+mkdir -p /srv/salt-overlay/pillar
+cat <<EOF >/srv/salt-overlay/pillar/cluster-params.sls
+instance_prefix: '$(echo "$INSTANCE_PREFIX" | sed -e "s/'/''/g")'
+node_instance_prefix: $NODE_INSTANCE_PREFIX
+service_cluster_ip_range: $SERVICE_CLUSTER_IP_RANGE
+enable_cluster_monitoring: "${ENABLE_CLUSTER_MONITORING:-none}"
+enable_cluster_logging: "${ENABLE_CLUSTER_LOGGING:false}"
+enable_cluster_ui: "${ENABLE_CLUSTER_UI:false}"
+enable_node_logging: "${ENABLE_NODE_LOGGING:false}"
+logging_destination: $LOGGING_DESTINATION
+elasticsearch_replicas: $ELASTICSEARCH_LOGGING_REPLICAS
+enable_cluster_dns: "${ENABLE_CLUSTER_DNS:-false}"
+dns_replicas: ${DNS_REPLICAS:-1}
+dns_server: $DNS_SERVER_IP
+dns_domain: $DNS_DOMAIN
+e2e_storage_test_environment: "${E2E_STORAGE_TEST_ENVIRONMENT:-false}"
+cluster_cidr: "$NODE_IP_RANGES"
+allocate_node_cidrs: "${ALLOCATE_NODE_CIDRS:-true}"
+EOF
+
+mkdir -p /srv/salt-overlay/salt/nginx
+echo $MASTER_HTPASSWD > /srv/salt-overlay/salt/nginx/htpasswd

--- a/cluster/photon-controller/templates/hostname.sh
+++ b/cluster/photon-controller/templates/hostname.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Copyright 2014 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Remove kube.vm from /etc/hosts
+sed -i -e 's/\b\w\+.vm\b//' /etc/hosts
+
+# Update hostname in /etc/hosts and /etc/hostname
+sed -i -e "s/\\bkube\\b/${MY_NAME}/g" /etc/host{s,name}
+hostname ${MY_NAME}

--- a/cluster/photon-controller/templates/install-release.sh
+++ b/cluster/photon-controller/templates/install-release.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Copyright 2014 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script assumes that the environment variable SERVER_BINARY_TAR contains
+# the release tar to download and unpack. It is meant to be pushed to the
+# master and run.
+
+echo "Unpacking Salt tree"
+rm -rf kubernetes
+tar xzf "${SALT_TAR}"
+
+echo "Running release install script"
+sudo kubernetes/saltbase/install.sh "${SERVER_BINARY_TAR}"

--- a/cluster/photon-controller/templates/salt-master.sh
+++ b/cluster/photon-controller/templates/salt-master.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+# Copyright 2014 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Use other Debian mirror
+sed -i -e "s/http.us.debian.org/mirrors.kernel.org/" /etc/apt/sources.list
+
+# Prepopulate the name of the Master
+mkdir -p /etc/salt/minion.d
+echo "master: $MASTER_NAME" > /etc/salt/minion.d/master.conf
+
+cat <<EOF >/etc/salt/minion.d/grains.conf
+grains:
+  roles:
+    - kubernetes-master
+  cbr-cidr: $MASTER_IP_RANGE
+  cloud: photon-controller
+EOF
+
+# Auto accept all keys from minions that try to join
+mkdir -p /etc/salt/master.d
+cat <<EOF >/etc/salt/master.d/auto-accept.conf
+auto_accept: True
+EOF
+
+cat <<EOF >/etc/salt/master.d/reactor.conf
+# React to new minions starting by running highstate on them.
+reactor:
+  - 'salt/minion/*/start':
+    - /srv/reactor/highstate-new.sls
+    - /srv/reactor/highstate-masters.sls
+    - /srv/reactor/highstate-minions.sls
+EOF
+
+# Install Salt
+#
+# We specify -X to avoid a race condition that can cause minion failure to
+# install.  See https://github.com/saltstack/salt-bootstrap/issues/270
+#
+# -M installs the master
+set +x
+curl -L --connect-timeout 20 --retry 6 --retry-delay 10 https://bootstrap.saltstack.com | sh -s -- -M -X
+set -x

--- a/cluster/photon-controller/templates/salt-minion.sh
+++ b/cluster/photon-controller/templates/salt-minion.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+# Copyright 2014 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Use other Debian mirror
+sed -i -e "s/http.us.debian.org/mirrors.kernel.org/" /etc/apt/sources.list
+
+# Resolve hostname of master
+if ! grep -q $KUBE_MASTER /etc/hosts; then
+  echo "Adding host entry for $KUBE_MASTER"
+  echo "$KUBE_MASTER_IP $KUBE_MASTER" >> /etc/hosts
+fi
+
+# Prepopulate the name of the Master
+mkdir -p /etc/salt/minion.d
+echo "master: $KUBE_MASTER" > /etc/salt/minion.d/master.conf
+
+# Turn on debugging for salt-minion
+# echo "DAEMON_ARGS=\"\$DAEMON_ARGS --log-file-level=debug\"" > /etc/default/salt-minion
+
+# Our minions will have a pool role to distinguish them from the master.
+#
+# Setting the "minion_ip" here causes the kubelet to use its IP for
+# identification instead of its hostname.
+#
+cat <<EOF >/etc/salt/minion.d/grains.conf
+grains:
+  hostname_override: $(ip route get 1.1.1.1 | awk '{print $7}')
+  roles:
+    - kubernetes-pool
+    - kubernetes-pool-photon-controller
+  cloud: photon-controller
+EOF
+
+# Install Salt
+#
+# We specify -X to avoid a race condition that can cause minion failure to
+# install.  See https://github.com/saltstack/salt-bootstrap/issues/270
+curl -L --connect-timeout 20 --retry 6 --retry-delay 10 https://bootstrap.saltstack.com | sh -s -- -X

--- a/cluster/photon-controller/util.sh
+++ b/cluster/photon-controller/util.sh
@@ -397,7 +397,7 @@ function gen-master-start {
     (
         echo "#! /bin/bash"
         echo "readonly MY_NAME=${MASTER_NAME}"
-        grep -v "^#" "${KUBE_ROOT}/cluster/vsphere/templates/hostname.sh"
+        grep -v "^#" "${KUBE_ROOT}/cluster/photon-controller/templates/hostname.sh"
         echo "cd /home/kube/cache/kubernetes-install"
         echo "readonly MASTER_NAME='${MASTER_NAME}'"
         echo "readonly MASTER_IP_RANGE='${MASTER_IP_RANGE}'"
@@ -417,9 +417,9 @@ function gen-master-start {
         echo "readonly SALT_TAR='${SALT_TAR##*/}'"
         echo "readonly MASTER_HTPASSWD='${htpasswd}'"
         echo "readonly E2E_STORAGE_TEST_ENVIRONMENT='${E2E_STORAGE_TEST_ENVIRONMENT:-}'"
-        grep -v "^#" "${KUBE_ROOT}/cluster/vsphere/templates/create-dynamic-salt-files.sh"
-        grep -v "^#" "${KUBE_ROOT}/cluster/vsphere/templates/install-release.sh"
-        grep -v "^#" "${KUBE_ROOT}/cluster/vsphere/templates/salt-master.sh"
+        grep -v "^#" "${KUBE_ROOT}/cluster/photon-controller/templates/create-dynamic-salt-files.sh"
+        grep -v "^#" "${KUBE_ROOT}/cluster/photon-controller/templates/install-release.sh"
+        grep -v "^#" "${KUBE_ROOT}/cluster/photon-controller/templates/salt-master.sh"
     ) > "${KUBE_TEMP}/master-start.sh"
 }
 
@@ -432,11 +432,11 @@ function gen-node-start {
         (
             echo "#! /bin/bash"
             echo "readonly MY_NAME=${NODE_NAMES[$i]}"
-            grep -v "^#" "${KUBE_ROOT}/cluster/vsphere/templates/hostname.sh"
+            grep -v "^#" "${KUBE_ROOT}/cluster/photon-controller/templates/hostname.sh"
             echo "KUBE_MASTER=${KUBE_MASTER}"
             echo "KUBE_MASTER_IP=${KUBE_MASTER_IP}"
             echo "NODE_IP_RANGE=$NODE_IP_RANGES"
-            grep -v "^#" "${KUBE_ROOT}/cluster/vsphere/templates/salt-minion.sh"
+            grep -v "^#" "${KUBE_ROOT}/cluster/photon-controller/templates/salt-minion.sh"
         ) > "${KUBE_TEMP}/node-start-${i}.sh"
   done
 }

--- a/cluster/saltbase/salt/README.md
+++ b/cluster/saltbase/salt/README.md
@@ -24,7 +24,7 @@ Config                                              | GCE   | Vagrant | AWS |
 [kubelet](kubelet/)                                 | M n   | M n     | M n |
 [logrotate](logrotate/)                             | M n   |   n     | M n |
 [supervisord](supervisor/)                          | M n   | M n     | M n |
-[static-routes](static-routes/) (vsphere only)      |       |         |     |
+[static-routes](static-routes/) (vsphere/photon)    |       |         |     |
 [base](base.sls)                                    | M n   | M n     | M n |
 [kube-client-tools](kube-client-tools.sls)          | M     | M       | M   |
 

--- a/cluster/saltbase/salt/docker/init.sls
+++ b/cluster/saltbase/salt/docker/init.sls
@@ -47,7 +47,7 @@ docker:
       - pkg: docker-io
 
 {% endif %}
-{% elif grains.cloud is defined and grains.cloud == 'vsphere' and grains.os == 'Debian' and grains.osrelease_info[0] >=8 %}
+{% elif grains.cloud is defined and (grains.cloud == 'vsphere' or grains.cloud == 'photon-controller') and grains.os == 'Debian' and grains.osrelease_info[0] >=8 %}
 
 {% if pillar.get('is_systemd') %}
 

--- a/cluster/saltbase/salt/generate-cert/init.sls
+++ b/cluster/saltbase/salt/generate-cert/init.sls
@@ -6,7 +6,7 @@
   {% if grains.cloud == 'aws' %}
     {% set cert_ip='_use_aws_external_ip_' %}
   {% endif %}
-  {% if grains.cloud == 'vsphere' %}
+  {% if grains.cloud == 'vsphere' or grains.cloud == 'photon-controller' %}
     {% set cert_ip=grains.ip_interfaces.eth0[0] %}
   {% endif %}
 {% endif %}

--- a/cluster/saltbase/salt/kube-apiserver/init.sls
+++ b/cluster/saltbase/salt/kube-apiserver/init.sls
@@ -1,5 +1,5 @@
 {% if grains.cloud is defined %}
-{% if grains.cloud in ['aws', 'gce', 'vagrant', 'vsphere'] %}
+{% if grains.cloud in ['aws', 'gce', 'vagrant', 'vsphere', 'photon-controller'] %}
 # TODO: generate and distribute tokens on other cloud providers.
 /srv/kubernetes/known_tokens.csv:
   file.managed:
@@ -12,7 +12,7 @@
 {% endif %}
 {% endif %}
 
-{% if grains['cloud'] is defined and grains.cloud in [ 'aws', 'gce', 'vagrant' ,'vsphere']  %}
+{% if grains['cloud'] is defined and grains.cloud in [ 'aws', 'gce', 'vagrant', 'vsphere', 'photon-controller']  %}
 /srv/kubernetes/basic_auth.csv:
   file.managed:
     - source: salt://kube-apiserver/basic_auth.csv

--- a/cluster/saltbase/salt/kube-apiserver/kube-apiserver.manifest
+++ b/cluster/saltbase/salt/kube-apiserver/kube-apiserver.manifest
@@ -14,7 +14,7 @@
 {% set srv_sshproxy_path = "/srv/sshproxy" -%}
 
 {% if grains.cloud is defined -%}
-  {% if grains.cloud not in ['vagrant', 'vsphere'] -%}
+  {% if grains.cloud not in ['vagrant', 'vsphere', 'photon-controller'] -%}
     {% set cloud_provider = "--cloud-provider=" + grains.cloud -%}
   {% endif -%}
 
@@ -58,7 +58,7 @@
 {% set client_ca_file = "" -%}
 
 {% set secure_port = "6443" -%}
-{% if grains['cloud'] is defined and grains.cloud in [ 'aws', 'gce', 'vagrant', 'vsphere' ]    %}
+{% if grains['cloud'] is defined and grains.cloud in [ 'aws', 'gce', 'vagrant', 'vsphere', 'photon-controller' ]    %}
   {% set secure_port = "443" -%}
   {% set client_ca_file = "--client-ca-file=/srv/kubernetes/ca.crt" -%}
 {% endif -%}
@@ -72,12 +72,12 @@
 {% endif -%}
 
 {% if grains.cloud is defined -%}
-{% if grains.cloud in [ 'aws', 'gce', 'vagrant', 'vsphere' ] -%}
+{% if grains.cloud in [ 'aws', 'gce', 'vagrant', 'vsphere', 'photon-controller' ] -%}
     {% set token_auth_file = "--token-auth-file=/srv/kubernetes/known_tokens.csv" -%}
 {% endif -%}
 {% endif -%}
 
-{% if grains['cloud'] is defined and grains.cloud in [ 'aws', 'gce', 'vagrant', 'vsphere']  %}
+{% if grains['cloud'] is defined and grains.cloud in [ 'aws', 'gce', 'vagrant', 'vsphere', 'photon-controller' ]  %}
   {% set basic_auth_file = "--basic-auth-file=/srv/kubernetes/basic_auth.csv" -%}
 {% endif -%}
 

--- a/cluster/saltbase/salt/kube-controller-manager/kube-controller-manager.manifest
+++ b/cluster/saltbase/salt/kube-controller-manager/kube-controller-manager.manifest
@@ -32,7 +32,7 @@
 {% set srv_kube_path = "/srv/kubernetes" -%}
 
 {% if grains.cloud is defined -%}
-  {% if grains.cloud not in ['vagrant', 'vsphere'] -%}
+  {% if grains.cloud not in ['vagrant', 'vsphere', 'photon-controller'] -%}
     {% set cloud_provider = "--cloud-provider=" + grains.cloud -%}
   {% endif -%}
   {% set service_account_key = "--service-account-private-key-file=/srv/kubernetes/server.key" -%}
@@ -46,7 +46,7 @@
 
 {% set root_ca_file = "" -%}
 
-{% if grains['cloud'] is defined and grains.cloud in [ 'aws', 'gce', 'vagrant', 'vsphere' ]    %}
+{% if grains['cloud'] is defined and grains.cloud in [ 'aws', 'gce', 'vagrant', 'vsphere', 'photon-controller' ]    %}
    {% set root_ca_file = "--root-ca-file=/srv/kubernetes/ca.crt" -%}
 {% endif -%}
 

--- a/cluster/saltbase/salt/kube-proxy/kube-proxy.manifest
+++ b/cluster/saltbase/salt/kube-proxy/kube-proxy.manifest
@@ -5,7 +5,7 @@
   {% set ips = salt['mine.get']('roles:kubernetes-master', 'network.ip_addrs', 'grain').values() -%}
   {% set api_servers = "--master=https://" + ips[0][0] -%}
 {% endif -%}
-{% if grains['cloud'] is defined and grains.cloud in [ 'aws', 'gce', 'vagrant', 'vsphere' ]  %}
+{% if grains['cloud'] is defined and grains.cloud in [ 'aws', 'gce', 'vagrant', 'vsphere', 'photon-controller' ]  %}
   {% set api_servers_with_port = api_servers -%}
 {% else -%}
   {% set api_servers_with_port = api_servers + ":6443" -%}

--- a/cluster/saltbase/salt/kubelet/default
+++ b/cluster/saltbase/salt/kubelet/default
@@ -16,7 +16,7 @@
 {% endif -%}
 
 # TODO: remove nginx for other cloud providers.
-{% if grains['cloud'] is defined and grains.cloud in [ 'aws', 'gce', 'vagrant', 'vsphere' ]  %}
+{% if grains['cloud'] is defined and grains.cloud in [ 'aws', 'gce', 'vagrant', 'vsphere', 'photon-controller' ]  %}
   {% set api_servers_with_port = api_servers -%}
 {% else -%}
   {% set api_servers_with_port = api_servers + ":6443" -%}
@@ -28,7 +28,7 @@
 
 {% set reconcile_cidr_args = "" -%}
 {% if grains['roles'][0] == 'kubernetes-master' -%}
-  {% if grains.cloud in ['aws', 'gce', 'vagrant', 'vsphere'] -%}
+  {% if grains.cloud in ['aws', 'gce', 'vagrant', 'vsphere', 'photon-controller'] -%}
 
     # Unless given a specific directive, disable registration for the kubelet
     # running on the master.
@@ -48,7 +48,7 @@
 {% endif -%}
 
 {% set cloud_provider = "" -%}
-{% if grains.cloud is defined and grains.cloud not in ['vagrant', 'vsphere'] -%}
+{% if grains.cloud is defined and grains.cloud not in ['vagrant', 'vsphere', 'photon-controller'] -%}
   {% set cloud_provider = "--cloud-provider=" + grains.cloud -%}
 {% endif -%}
 

--- a/cluster/saltbase/salt/top.sls
+++ b/cluster/saltbase/salt/top.sls
@@ -55,7 +55,7 @@ base:
     - kube-controller-manager
     - kube-scheduler
     - supervisor
-{% if grains['cloud'] is defined and not grains.cloud in [ 'aws', 'gce', 'vagrant', 'vsphere'] %}
+{% if grains['cloud'] is defined and not grains.cloud in [ 'aws', 'gce', 'vagrant', 'vsphere', 'photon-controller'] %}
     - nginx
 {% endif %}
     - cadvisor
@@ -73,7 +73,7 @@ base:
     - logrotate
 {% endif %}
     - kube-addons
-{% if grains['cloud'] is defined and grains['cloud'] in [ 'vagrant', 'gce', 'aws', 'vsphere' ] %}
+{% if grains['cloud'] is defined and grains['cloud'] in [ 'vagrant', 'gce', 'aws', 'vsphere', 'photon-controller' ] %}
     - docker
     - kubelet
 {% endif %}


### PR DESCRIPTION
Kube-up uses salt to configure the Kubernetes VMs. Previously, we
"cheated" and used exactly the same salt configuration that vsphere
usess. In fact, salt thought we were vsphere. This separates us from
vsphere. Specifically:

* Copied the script templates from vsphere to photon-controller. These
  are unchanged in functionality, except for the line that change our
  identification from 'vsphere' to 'photon-controller'.

* Changed util.sh to use the templates in their new location.

* Changed the salt configuration to know about photon-controller. As
  of this commit, we treat it identically to vsphere. That is, we are
  different in name only: this change does not affect our
  functionality.