### PR TITLE
Make region and failure domain configurable by the user. Removed code…

### DIFF
--- a/cluster/vsphere/config-common.sh
+++ b/cluster/vsphere/config-common.sh
@@ -33,3 +33,5 @@ SSH_OPTS="-oStrictHostKeyChecking=no -oUserKnownHostsFile=/dev/null -oLogLevel=E
 # Set GOVC_INSECURE if the host in GOVC_URL is using a certificate that cannot
 # be verified (i.e. a self-signed certificate), but IS trusted.
 # export GOVC_INSECURE=1
+# export GOVC_REGION='region' # The region where the VM is deployed
+# export GOVC_FAILUREDOMAIN='failure-domain' # The fault domain to which VM is assigned to

--- a/cluster/vsphere/templates/salt-master.sh
+++ b/cluster/vsphere/templates/salt-master.sh
@@ -32,6 +32,8 @@ cat <<EOF > $CLOUD_CONFIG
         insecure-flag = $GOVC_INSECURE
         datacenter = $GOVC_DATACENTER
         datastore = $GOVC_DATASTORE
+        region = $GOVC_REGION
+        failure-domain = $GOVC_FAILUREDOMAIN
 
 [Disk]
 	scsicontrollertype = pvscsi

--- a/cluster/vsphere/templates/salt-minion.sh
+++ b/cluster/vsphere/templates/salt-minion.sh
@@ -42,6 +42,8 @@ cat <<EOF > $CLOUD_CONFIG
         insecure-flag = $GOVC_INSECURE
         datacenter = $GOVC_DATACENTER
         datastore = $GOVC_DATASTORE
+        region = $GOVC_REGION
+        failure-domain = $GOVC_FAILUREDOMAIN
 
 [Disk]
 	scsicontrollertype = pvscsi

--- a/cluster/vsphere/util.sh
+++ b/cluster/vsphere/util.sh
@@ -407,6 +407,8 @@ function kube-up {
     echo "readonly GOVC_INSECURE='${GOVC_INSECURE}'"
     echo "readonly GOVC_DATACENTER='${GOVC_DATACENTER}'"
     echo "readonly GOVC_DATASTORE='${GOVC_DATASTORE}'"
+    echo "readonly GOVC_REGION='${GOVC_REGION}'"
+    echo "readonly GOVC_FAILUREDOMAIN='${GOVC_FAILUREDOMAIN}'"
     grep -v "^#" "${KUBE_ROOT}/cluster/vsphere/templates/create-dynamic-salt-files.sh"
     grep -v "^#" "${KUBE_ROOT}/cluster/vsphere/templates/install-release.sh"
     grep -v "^#" "${KUBE_ROOT}/cluster/vsphere/templates/salt-master.sh"
@@ -435,6 +437,8 @@ function kube-up {
       echo "readonly GOVC_INSECURE='${GOVC_INSECURE}'"
       echo "readonly GOVC_DATACENTER='${GOVC_DATACENTER}'"
       echo "readonly GOVC_DATASTORE='${GOVC_DATASTORE}'"
+      echo "readonly GOVC_REGION='${GOVC_REGION}'"
+      echo "readonly GOVC_FAILUREDOMAIN='${GOVC_FAILUREDOMAIN}'"
       grep -v "^#" "${KUBE_ROOT}/cluster/vsphere/templates/salt-minion.sh"
     ) > "${KUBE_TEMP}/node-start-${i}.sh"
 


### PR DESCRIPTION
The current fix will take a configurable values of region and fault domain from the user. The zone will comprise of these values which in turn will be used Kubernetes in making decision on where to deploy the node/pod. 

Previously, once the node is deployed the code will try to retrieve the cluster name and datacenter and use it to assign to failure domain and region respectively. This information varies from each vcenter set up to set up. We should not limit to always pick up these values which doesn't any sense in current scenario. Also the existing implementation panics sometimes - see issue 36295 for more details. 

@abrarshivani @pdhamdhere @kerneltime 
