### PR TITLE
updated e2e tests to run for vsphere provider

### DIFF
--- a/pkg/cloudprovider/providers/vsphere/vsphere_util.go
+++ b/pkg/cloudprovider/providers/vsphere/vsphere_util.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vsphere
+
+import (
+	"context"
+	"os"
+	"runtime"
+	"strconv"
+)
+
+// Reads vSphere configuration from system environment and construct vSphere object
+func GetVSphere() (*VSphere, error) {
+	var cfg VSphereConfig
+	var insecureFlag bool
+	var err error
+	cfg.Global.VCenterIP = os.Getenv("VSPHERE_VCENTER")
+	cfg.Global.VCenterPort = os.Getenv("VSPHERE_VCENTER_PORT")
+	cfg.Global.User = os.Getenv("VSPHERE_USER")
+	cfg.Global.Password = os.Getenv("VSPHERE_PASSWORD")
+	cfg.Global.Datacenter = os.Getenv("VSPHERE_DATACENTER")
+	cfg.Global.Datastore = os.Getenv("VSPHERE_DATASTORE")
+	cfg.Global.WorkingDir = os.Getenv("VSPHERE_WORKING_DIR")
+
+	if os.Getenv("VSPHERE_INSECURE") != "" {
+		insecureFlag, err = strconv.ParseBool(os.Getenv("VSPHERE_INSECURE"))
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		insecureFlag = false
+	}
+	cfg.Global.InsecureFlag = insecureFlag
+
+	c, err := newClient(context.TODO(), &cfg)
+	if err != nil {
+		return nil, err
+	}
+	vs := VSphere{
+		client:          c,
+		cfg:             &cfg,
+		localInstanceID: "",
+	}
+	runtime.SetFinalizer(&vs, logout)
+	return &vs, nil
+}

--- a/test/e2e/pv_reclaimpolicy.go
+++ b/test/e2e/pv_reclaimpolicy.go
@@ -1,0 +1,195 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"time"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/kubernetes/pkg/api/v1"
+	"k8s.io/kubernetes/test/e2e/framework"
+	"k8s.io/kubernetes/pkg/api/resource"
+	"k8s.io/kubernetes/pkg/client/clientset_generated/clientset"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	vsphere "k8s.io/kubernetes/pkg/cloudprovider/providers/vsphere"
+	"k8s.io/kubernetes/pkg/volume/util/volumehelper"
+)
+
+var _ = framework.KubeDescribe("persistentvolumereclaim", func() {
+	f := framework.NewDefaultFramework("persistentvolumereclaim")
+	var c clientset.Interface
+	var ns string
+
+	BeforeEach(func() {
+		framework.SkipUnlessProviderIs("vsphere")
+		c = f.ClientSet
+		ns = f.Namespace.Name
+		framework.ExpectNoError(framework.WaitForAllNodesSchedulable(c, framework.TestContext.NodeSchedulableTimeout))
+	})
+
+	framework.KubeDescribe("persistentvolumereclaim:delete", func() {
+		var (
+			volumePath    string
+			pv            *v1.PersistentVolume
+			pvc           *v1.PersistentVolumeClaim
+			volumeoptions vsphere.VolumeOptions
+		)
+
+		It("should delete persistent volume when reclaimPolicy set to delete and associated claim is deleted", func() {
+
+			By("creating vmdk")
+			vsp, err := vsphere.GetVSphere()
+			Expect(err).NotTo(HaveOccurred())
+
+			volumeoptions.CapacityKB = 2097152
+			volumeoptions.Name = "e2e-disk" + time.Now().Format("20060102150405")
+			volumeoptions.DiskFormat = "thin"
+			volumePath, err = vsp.CreateVolume(&volumeoptions)
+
+			Expect(err).NotTo(HaveOccurred())
+			pv = getPersistentVolumeSpec(volumePath, v1.PersistentVolumeReclaimDelete)
+			pv, err := c.CoreV1().PersistentVolumes().Create(pv)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("creating the pv")
+			pvc = getPersistentVolumeClaimSpec(ns)
+
+			pvc, err := c.CoreV1().PersistentVolumeClaims(ns).Create(pvc)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("wait for the pv and pvc")
+			waitOnPVandPVC(c, ns, pv, pvc)
+
+			By("delete pvc")
+			deletePersistentVolumeClaim(c, pvc.Name, ns)
+
+			By("verify pv is deleted")
+			err = framework.WaitForPersistentVolumeDeleted(c, pv.Name, 3*time.Second, 300*time.Second)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	framework.KubeDescribe("persistentvolumereclaim:retain", func() {
+		var (
+			volumePath    string
+			pv            *v1.PersistentVolume
+			pvc           *v1.PersistentVolumeClaim
+			volumeoptions vsphere.VolumeOptions
+		)
+
+		It("should retain persistent volume when reclaimPolicy set to retain when associated claim is deleted", func() {
+
+			By("creating vmdk")
+			vsp, err := vsphere.GetVSphere()
+			Expect(err).NotTo(HaveOccurred())
+
+			volumeoptions.CapacityKB = 2097152
+			volumeoptions.Name = "e2e-disk" + time.Now().Format("20060102150405")
+			volumeoptions.DiskFormat = "thin"
+			volumePath, err = vsp.CreateVolume(&volumeoptions)
+
+			Expect(err).NotTo(HaveOccurred())
+			pv = getPersistentVolumeSpec(volumePath, v1.PersistentVolumeReclaimRetain)
+			pv, err := c.CoreV1().PersistentVolumes().Create(pv)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("creating the pv")
+			pvc = getPersistentVolumeClaimSpec(ns)
+
+			pvc, err := c.CoreV1().PersistentVolumeClaims(ns).Create(pvc)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("wait for the pv and pvc")
+			waitOnPVandPVC(c, ns, pv, pvc)
+
+			By("delete pvc")
+			deletePersistentVolumeClaim(c, pvc.Name, ns)
+
+			By("verify pv is retained")
+			framework.Logf("Waiting for PV %v to become Released", pv.Name)
+			err = framework.WaitForPersistentVolumePhase(v1.VolumeReleased, c, pv.Name, 3*time.Second, 300*time.Second)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("delete pv")
+			deletePersistentVolume(c, pv.Name)
+			err = framework.WaitForPersistentVolumeDeleted(c, pv.Name, 3*time.Second, 300*time.Second)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+})
+
+func getPersistentVolumeSpec(volumePath string, persistentVolumeReclaimPolicy v1.PersistentVolumeReclaimPolicy) (*v1.PersistentVolume) {
+	var (
+		pvConfig persistentVolumeConfig
+		pv       *v1.PersistentVolume
+		claimRef *v1.ObjectReference
+	)
+	pvConfig = persistentVolumeConfig{
+		namePrefix: "vspherepv-",
+		pvSource: v1.PersistentVolumeSource{
+			VsphereVolume: &v1.VsphereVirtualDiskVolumeSource{
+				VolumePath:            volumePath,
+				FSType:                "ext4",
+			},
+		},
+		prebind: nil,
+	}
+
+	pv = &v1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: pvConfig.namePrefix,
+			Annotations: map[string]string{
+				volumehelper.VolumeGidAnnotationKey: "777",
+			},
+		},
+		Spec: v1.PersistentVolumeSpec{
+			PersistentVolumeReclaimPolicy: persistentVolumeReclaimPolicy,
+			Capacity: v1.ResourceList{
+				v1.ResourceName(v1.ResourceStorage): resource.MustParse("2Gi"),
+			},
+			PersistentVolumeSource: pvConfig.pvSource,
+			AccessModes: []v1.PersistentVolumeAccessMode{
+				v1.ReadWriteOnce,
+			},
+			ClaimRef: claimRef,
+		},
+	}
+	return pv
+}
+
+func getPersistentVolumeClaimSpec(namespace string) (*v1.PersistentVolumeClaim) {
+	var (
+		pvc *v1.PersistentVolumeClaim
+	)
+	pvc = &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "pvc-",
+			Namespace:    namespace,
+		},
+		Spec: v1.PersistentVolumeClaimSpec{
+			AccessModes: []v1.PersistentVolumeAccessMode{
+				v1.ReadWriteOnce,
+			},
+			Resources: v1.ResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceName(v1.ResourceStorage): resource.MustParse("2Gi"),
+				},
+			},
+		},
+	}
+	return pvc
+}

--- a/test/e2e/pvc_label_selector.go
+++ b/test/e2e/pvc_label_selector.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"time"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/kubernetes/pkg/api/v1"
+	"k8s.io/kubernetes/test/e2e/framework"
+	"k8s.io/kubernetes/pkg/client/clientset_generated/clientset"
+	vsphere "k8s.io/kubernetes/pkg/cloudprovider/providers/vsphere"
+)
+
+var _ = framework.KubeDescribe("pvclabelselector", func() {
+	f := framework.NewDefaultFramework("pvclabelselector")
+	var c clientset.Interface
+	var ns string
+
+	BeforeEach(func() {
+		framework.SkipUnlessProviderIs("vsphere")
+		c = f.ClientSet
+		ns = f.Namespace.Name
+		framework.ExpectNoError(framework.WaitForAllNodesSchedulable(c, framework.TestContext.NodeSchedulableTimeout))
+	})
+
+	framework.KubeDescribe("Selector-Label Volume Binding", func() {
+		var (
+			volumePath    string
+			pv_ssd            *v1.PersistentVolume
+			pvc_ssd           *v1.PersistentVolumeClaim
+			pvc_vvol           *v1.PersistentVolumeClaim
+			volumeoptions vsphere.VolumeOptions
+		)
+
+		It("should bind volume with claim for given label", func() {
+
+			By("creating vmdk")
+			vsp, err := vsphere.GetVSphere()
+			Expect(err).NotTo(HaveOccurred())
+
+			volumeoptions.CapacityKB = 2097152
+			volumeoptions.Name = "e2e-disk" + time.Now().Format("20060102150405")
+			volumeoptions.DiskFormat = "thin"
+
+			volumePath, err = vsp.CreateVolume(&volumeoptions)
+			Expect(err).NotTo(HaveOccurred())
+
+
+			By("creating the pv with lable volume-type:ssd")
+			ssdlabels := make(map[string]string)
+			ssdlabels["volume-type"]="ssd"
+			pv_ssd = getVspherePersistentVolumeSpec(volumePath, v1.PersistentVolumeReclaimDelete, ssdlabels)
+			pv_ssd, err := c.CoreV1().PersistentVolumes().Create(pv_ssd)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("creating pvc with label selector to match with volume-type:vvol")
+			vvollabels := make(map[string]string)
+			vvollabels["volume-type"]="vvol"
+			pvc_vvol = getvSpherePersistentVolumeClaimSpec(ns,vvollabels)
+			pvc_vvol, err := c.CoreV1().PersistentVolumeClaims(ns).Create(pvc_vvol)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("creating pvc with label selector to match with volume-type:ssd")
+			pvc_ssd = getvSpherePersistentVolumeClaimSpec(ns, ssdlabels)
+			pvc_ssd, err := c.CoreV1().PersistentVolumeClaims(ns).Create(pvc_ssd)
+
+			By("wait for the pvc_ssd to bind with pv_ssd")
+			waitOnPVandPVC(c, ns, pv_ssd, pvc_ssd)
+
+			By("Verify status of pvc_vvol is pending")
+			err =framework.WaitForPersistentVolumeClaimPhase(v1.ClaimPending, c, ns, pvc_vvol.Name, 3*time.Second, 300*time.Second)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("delete pvc_ssd")
+			deletePersistentVolumeClaim(c, pvc_ssd.Name, ns)
+
+			By("verify pv_ssd is deleted")
+			err = framework.WaitForPersistentVolumeDeleted(c, pv_ssd.Name, 3*time.Second, 300*time.Second)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("delete pvc_vvol")
+			deletePersistentVolumeClaim(c, pvc_vvol.Name, ns)
+		})
+	})
+})
+

--- a/test/e2e/volume_provisioning.go
+++ b/test/e2e/volume_provisioning.go
@@ -54,12 +54,16 @@ func testDynamicProvisioning(client clientset.Interface, claim *v1.PersistentVol
 
 	// Check sizes
 	expectedCapacity := resource.MustParse(expectedSize)
+	if framework.ProviderIs("vsphere") {
+		// vsphere provider does not allocate volumes in 1GiB chunks
+		expectedCapacity = resource.MustParse(requestedSize)
+	}
 	pvCapacity := pv.Spec.Capacity[v1.ResourceName(v1.ResourceStorage)]
-	Expect(pvCapacity.Value()).To(Equal(expectedCapacity.Value()))
+	Expect(pvCapacity.Value()).To(Equal(expectedCapacity.Value()),"pvCapacity is not equal to expectedCapacity")
 
 	requestedCapacity := resource.MustParse(requestedSize)
 	claimCapacity := claim.Spec.Resources.Requests[v1.ResourceName(v1.ResourceStorage)]
-	Expect(claimCapacity.Value()).To(Equal(requestedCapacity.Value()))
+	Expect(claimCapacity.Value()).To(Equal(requestedCapacity.Value()),"claimCapacity is not equal to requestedCapacity")
 
 	// Check PV properties
 	Expect(pv.Spec.PersistentVolumeReclaimPolicy).To(Equal(v1.PersistentVolumeReclaimDelete))
@@ -103,7 +107,7 @@ var _ = framework.KubeDescribe("Dynamic provisioning", func() {
 
 	framework.KubeDescribe("DynamicProvisioner", func() {
 		It("should create and delete persistent volumes [Slow] [Volume]", func() {
-			framework.SkipUnlessProviderIs("openstack", "gce", "aws", "gke")
+			framework.SkipUnlessProviderIs("openstack", "gce", "aws", "gke", "vsphere")
 
 			By("creating a StorageClass")
 			class := newStorageClass()
@@ -125,7 +129,7 @@ var _ = framework.KubeDescribe("Dynamic provisioning", func() {
 
 	framework.KubeDescribe("DynamicProvisioner Alpha", func() {
 		It("should create and delete alpha persistent volumes [Slow] [Volume]", func() {
-			framework.SkipUnlessProviderIs("openstack", "gce", "aws", "gke")
+			framework.SkipUnlessProviderIs("openstack", "gce", "aws", "gke", "vsphere")
 
 			By("creating a claim with an alpha dynamic provisioning annotation")
 			claim := newClaim(ns, true)
@@ -229,6 +233,8 @@ func newStorageClass() *storage.StorageClass {
 		pluginName = "kubernetes.io/aws-ebs"
 	case framework.ProviderIs("openstack"):
 		pluginName = "kubernetes.io/cinder"
+	case framework.ProviderIs("vsphere"):
+		pluginName = "kubernetes.io/vsphere-volume"
 	}
 
 	return &storage.StorageClass{

--- a/test/e2e/vsphere_node_selector.go
+++ b/test/e2e/vsphere_node_selector.go
@@ -1,0 +1,241 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"time"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/kubernetes/test/e2e/framework"
+	"k8s.io/kubernetes/pkg/api/v1"
+	"k8s.io/kubernetes/pkg/client/clientset_generated/clientset"
+	"k8s.io/apimachinery/pkg/types"
+	vsphere "k8s.io/kubernetes/pkg/cloudprovider/providers/vsphere"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/pkg/util/uuid"
+)
+
+var _ = framework.KubeDescribe("basic-vsphere-volume-plugin-tests", func() {
+	f := framework.NewDefaultFramework("basic-vsphere-volume-plugin-tests")
+	var (
+		c                  clientset.Interface
+		ns                 string
+		volumePath         string
+		node1Name          string
+		node1LabelValue    string
+		node1KeyValueLabel map[string]string
+
+		node2Name          string
+		node2LabelValue    string
+		node2KeyValueLabel map[string]string
+
+		isNodeLabeled bool
+	)
+	BeforeEach(func() {
+		framework.SkipUnlessProviderIs("vsphere")
+		c = f.ClientSet
+		ns = f.Namespace.Name
+		framework.ExpectNoError(framework.WaitForAllNodesSchedulable(c, framework.TestContext.NodeSchedulableTimeout))
+
+		if (!isNodeLabeled) {
+			nodeList := framework.GetReadySchedulableNodesOrDie(f.ClientSet)
+			if (len(nodeList.Items) != 0) {
+				node1Name = nodeList.Items[0].Name
+				node2Name = nodeList.Items[1].Name
+			} else {
+				framework.Failf("Unable to find ready and schedulable Node")
+			}
+			node1LabelValue = "vsphere_e2e_" + string(uuid.NewUUID())
+			node1KeyValueLabel = make(map[string]string)
+			node1KeyValueLabel["vsphere_e2e_label"] = node1LabelValue
+			framework.AddOrUpdateLabelOnNode(c, node1Name, "vsphere_e2e_label", node1LabelValue)
+
+			node2LabelValue = "vsphere_e2e_" + string(uuid.NewUUID())
+			node2KeyValueLabel = make(map[string]string)
+			node2KeyValueLabel["vsphere_e2e_label"] = node2LabelValue
+			framework.AddOrUpdateLabelOnNode(c, node2Name, "vsphere_e2e_label", node2LabelValue)
+
+		}
+
+	})
+
+	AddCleanupAction(func() {
+		By("Running clean up actions")
+		if len(node1LabelValue) > 0 {
+			framework.RemoveLabelOffNode(c, node1Name, "vsphere_e2e_label")
+		}
+		if len(node2LabelValue) > 0 {
+			framework.RemoveLabelOffNode(c, node2Name, "vsphere_e2e_label")
+		}
+	})
+
+	framework.KubeDescribe("Test Back-to-back pod creation/deletion with the same volume source on the same worker node", func() {
+		var volumeoptions vsphere.VolumeOptions
+		It("should provision pod on the node with matching label", func() {
+			By("creating vmdk")
+			vsp, err := vsphere.GetVSphere()
+			Expect(err).NotTo(HaveOccurred())
+
+			volumeoptions.CapacityKB = 2097152
+			volumeoptions.Name = "e2e-disk" + time.Now().Format("20060102150405")
+			volumeoptions.DiskFormat = "thin"
+
+			volumePath, err = vsp.CreateVolume(&volumeoptions)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Creating pod on the node: " + node1Name)
+			pod := getPodSpec(volumePath, node1KeyValueLabel)
+
+			pod, err = c.CoreV1().Pods(ns).Create(pod)
+			Expect(err).NotTo(HaveOccurred())
+			By("Waiting for pod to be ready")
+			Expect(f.WaitForPodRunning(pod.Name)).To(Succeed())
+
+			By("Verify volume is attached to the node: " + node1Name)
+			verifyVsphereDiskAttached(volumePath, types.NodeName(node1Name))
+
+			By("Deleting pod")
+			err = c.CoreV1().Pods(ns).Delete(pod.Name, nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Waiting for volume to be detached from the node")
+			waitForVSphereDiskToDetach(volumePath, types.NodeName(node1Name))
+
+			By("Creating pod on the same node: " + node1Name)
+			pod = getPodSpec(volumePath, node1KeyValueLabel)
+			pod, err = c.CoreV1().Pods(ns).Create(pod)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Waiting for pod to be running")
+			Expect(f.WaitForPodRunning(pod.Name)).To(Succeed())
+
+			By("Verify volume is attached to the node: " + node1Name)
+			verifyVsphereDiskAttached(volumePath, types.NodeName(node1Name))
+
+			By("Deleting pod")
+			err = c.CoreV1().Pods(ns).Delete(pod.Name, nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Waiting for volume to be detached from the node: " + node1Name)
+			waitForVSphereDiskToDetach(volumePath, types.NodeName(node1Name))
+
+			By("Deleting vmdk")
+			if len(volumePath) > 0 {
+				vsp.DeleteVolume(volumePath)
+			}
+		})
+	})
+	framework.KubeDescribe("Test Back-to-back pod creation/deletion with the same volume source attach/detach to different worker nodes", func() {
+		var volumeoptions vsphere.VolumeOptions
+		It("should provision pod on the node with matching label", func() {
+			By("creating vmdk")
+			vsp, err := vsphere.GetVSphere()
+			Expect(err).NotTo(HaveOccurred())
+
+			volumeoptions.CapacityKB = 2097152
+			volumeoptions.Name = "e2e-disk" + time.Now().Format("20060102150405")
+			volumeoptions.DiskFormat = "thin"
+
+			volumePath, err = vsp.CreateVolume(&volumeoptions)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Creating pod on the node: " + node1Name)
+			pod := getPodSpec(volumePath, node1KeyValueLabel)
+
+			pod, err = c.CoreV1().Pods(ns).Create(pod)
+			Expect(err).NotTo(HaveOccurred())
+			By("Waiting for pod to be ready")
+			Expect(f.WaitForPodRunning(pod.Name)).To(Succeed())
+
+			By("Verify volume is attached to the node: " + node1Name)
+			verifyVsphereDiskAttached(volumePath, types.NodeName(node1Name))
+
+			By("Deleting pod")
+			err = c.CoreV1().Pods(ns).Delete(pod.Name, nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Waiting for volume to be detached from the node")
+			waitForVSphereDiskToDetach(volumePath, types.NodeName(node1Name))
+
+			By("Creating pod on the another node: " + node2Name)
+			pod = getPodSpec(volumePath, node2KeyValueLabel)
+			pod, err = c.CoreV1().Pods(ns).Create(pod)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Waiting for pod to be running")
+			Expect(f.WaitForPodRunning(pod.Name)).To(Succeed())
+
+			By("Verify volume is attached to the node: " + node2Name)
+			verifyVsphereDiskAttached(volumePath, types.NodeName(node2Name))
+
+			By("Deleting pod")
+			err = c.CoreV1().Pods(ns).Delete(pod.Name, nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Waiting for volume to be detached from the node: " + node2Name)
+			waitForVSphereDiskToDetach(volumePath, types.NodeName(node2Name))
+
+			By("Deleting vmdk")
+			if len(volumePath) > 0 {
+				vsp.DeleteVolume(volumePath)
+			}
+		})
+	})
+})
+
+func getPodSpec(volumePath string, keyValuelabel map[string]string) (*v1.Pod) {
+	pod := &v1.Pod{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Pod",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "vsphere-e2e-",
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name:    "vsphere-e2e-container-" + string(uuid.NewUUID()),
+					Image:   "gcr.io/google-containers/test-webserver",
+					VolumeMounts: []v1.VolumeMount{
+						{
+							Name:      "vsphere-volume",
+							MountPath: "/mnt/vsphere-volume",
+						},
+					},
+				},
+			},
+			RestartPolicy: v1.RestartPolicyNever,
+			Volumes: []v1.Volume{
+				{
+					Name: "vsphere-volume",
+					VolumeSource: v1.VolumeSource{
+						VsphereVolume: &v1.VsphereVirtualDiskVolumeSource{
+							VolumePath:   volumePath,
+							FSType:       "ext4",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if (keyValuelabel != nil) {
+		pod.Spec.NodeSelector = keyValuelabel
+	}
+	return pod
+}


### PR DESCRIPTION
Following is the summary of change

**pkg/cloudprovider/providers/vsphere/vsphere.go**
- Added GetVSphere() to read vSphere configuration from system environment and return constructed vSphere object for test cases located in e2e package.

**test/e2e/persistent_volumes.go**
- This test verifies
         - deleting a PVC before the pod does not cause pod deletion to fail on PD detach and 
         - deleting the PV before the pod does not cause pod deletion to fail on PD detach
- Added function verifyVsphereDiskAttached to verify if volume is attached to the node.
- Added function waitForVSphereDiskToDetach to allow test to wait until volume is detached from the node.

**test/e2e/volume_provisioning.go**
- This test creates a StorageClass and claim with dynamic provisioning and alpha dynamic provisioning annotations and verifies that required volumes are getting created. Test also verifies that created volume is readable and retaining data.

- Added vsphere as supported cloud provider. Also set pluginName to "kubernetes.io/vsphere-volume" for vsphere cloud provider.

**test/e2e/volumes.go**
- This test creates requested volume, mount it on the pod, write some random content at /opt/0/index.html and verifies file contents are perfect to make sure we don't see the content from previous test runs.
- This test also passes "1234" as fsGroup to mount volume and verifies fsGroup is set correctly.


@kerneltime , @BaluDontu Can you please provide review comments?

**Steps to execute these e2e test cases.**

-  Build e2e

`make quick-release`

- Setup up Environment
```
export KUBERNETES_PROVIDER=vsphere
export KUBERNETES_ANYWHERE_PATH=/Users/divyenp/github/kubernetes/kubernetes-anywhere
export KUBECONFIG=$KUBERNETES_ANYWHERE_PATH/phase1/vsphere/.tmp/kubeconfig.json
export KUBERNETES_CONFORMANCE_PROVIDER="vsphere"
export KUBERNETES_CONFORMANCE_TEST=Y
export VSPHERE_VCENTER=10.192.69.244
export VSPHERE_VCENTER_PORT=443
export VSPHERE_USER=Administrator@vsphere.local
export VSPHERE_PASSWORD='Admin!23'
export VSPHERE_DATACENTER=vcqaDC
export VSPHERE_DATASTORE=vsanDatastore
export VSPHERE_INSECURE=true
export VSPHERE_WORKING_DIR='/vcqaDC/vm/kubernetes/'
```
- Run tests

`go run hack/e2e.go --check_version_skew=false -v -test --test_args='--ginkgo.focus=PersistentVolumes:vsphere'`

`go run hack/e2e.go --check_version_skew=false -v -test --test_args='--ginkgo.focus=Dynamic\sprovisioning\s\[k8s\.io\]'`

`go run hack/e2e.go --check_version_skew=false -v -test --test_args='--ginkgo.focus=vsphere\sshould\sbe\smountable'`

`go run hack/e2e.go --check_version_skew=false -v -test --test_args='--ginkgo.focus=persistentvolumereclaim'`


