### PR TITLE
VSAN policy support in Kubernetes

### DIFF
--- a/examples/volumes/vsphere/README.md
+++ b/examples/volumes/vsphere/README.md
@@ -410,7 +410,7 @@
 
       [Download example](vsphere-volume-sc-vsancapabilities-with-datastore.yaml?raw=true)
 
-      __Note: If you do not apply a storage policy during dynamic provisioning on a VSAN datastore, it will use a default Virtual SAN policy with one number of failures to tolerate, a single disk stripe per object, and a thin-provisioned virtual disk.__
+      __Note: If you do not apply a storage policy during dynamic provisioning on a VSAN datastore, it will use a default Virtual SAN policy.__
 
       Creating the storageclass:
 

--- a/examples/volumes/vsphere/README.md
+++ b/examples/volumes/vsphere/README.md
@@ -355,41 +355,6 @@
       ```
 
 ### Virtual SAN policy support inside Kubernetes
-####About Virtual SAN Storage Policies####
-  Virtual SAN Storage Polices define storage requirements, such as performance and availability for your virtual machines. These policies determine how the virtual machine storage objects are provisioned and allocated within the datastore to guarantee the required level of service. When you enable Virtual SAN on a host cluster, a single Virtual SAN datastore is created and a default storage policy is assigned to the datastore.
-
-  A storage capability is typically represented by a key-value pair, where the key is a specific property that the datastore can offer and the value is a metric that the datastore guarantees for a provisioned object, such as a virtual machine metadata object or a virtual disk. When you know the storage requirements of your virtual machines, you can create a storage policy referencing capabilities that the datastore advertises. You can create several policies to capture different types or classes of requirements.
-
-####Using Virtual SAN Storage Capabilities for storage volume provisioning for containers inside Kubernetes###
-  Since Virtual SAN is one of the supported vSphere Storage backends with the vSphere cloud provider, VI Admins will also have the ability to specify custom Virtual SAN Storage Capabilities during dynamic volume provisioning. Inturn these Virtual SAN Policies are assigned to underlying virtual disk. Thus, vSphere Cloud Provider enables policy driven dynamic provisioning of kubernetes persistent volumes. It exposes data services offered by the underlying storage platform such as Virtual SAN at granularity of container volumes and provides applications a complete abstraction of storage infrastructure.
-
-  Below is list of all Virtual SAN storage capabilties supported for storage volume provisioning:
-  * `hostFailuresToTolerate`
-    * Defines the number of host, disk, or network failures a storage object can tolerate. When the fault tolerance method is mirroring: to tolerate "n" failures, "n+1" copies of the object are created and "2n+1" hosts contributing storage are required (if fault domains are configured, "2n+1" fault domains with hosts contributing storage are required). When the fault tolerance method is erasure coding: to tolerate 1 failure, 4 hosts (or fault domains) are required; and to tolerate 2 failures, 6 hosts (or fault domains) are required. Note: A host which is not part of a fault domain is counted as its own single-host fault domain.
-    * Default value: 1, Maximum value: 3.
-
-  * `cacheReservation`
-    * Flash capacity reserved as read cache for the storage object. Specified as a percentage of the logical size of the object. To be used only for addressing read performance issues. Reserved flash capacity cannot be used by other objects. Unreserved flash is shared fairly among all objects. It is specified in parts per million.
-    * This value is expressed in percentage. Default value: 0, Maximum value: 100.
-
-  * `diskStripes`
-    * The number of HDDs across which each replica of storage object is striped. A value higher than 1 may result in better performance (for e.g when flash read cache misses need to get serviced from HDD), but also results in higher used of system resources. 
-    * Default value: 1, Maximum value: 12.
-
-  * `objectSpaceReservation`
-    * Percentage of the logical size of the storage object that will be reserved (thick provisioning) upon VM provisioning. The rest of the storage object is thin provisioned. 
-    * This value is expressed in percentage. Default value: 0, Maximum value: 100.
-
-  * `iopsLimit`
-    * Defines upper IOPS limit for a disk. IO rate that has been serviced on a disk will be measured and if the rate exceeds the IOPS limit, IO will be delayed to keep it under the limit. Zero value means no limit.
-    * Default value: 0.
-
-  * `forceProvisioning`
-    * If this option is "1" the object will be provisioned even if the policy specified in the storage policy is not satisfiable with the resources currently available in the cluster. Virtual SAN will try to bring the object into compliance if and when resources become available.
-    * Value can be either O or 1.
-
-  __Note: If you do not apply a storage policy during dynamic provisioning on a VSAN datastore, it will use a default Virtual SAN policy with one number of failures to tolerate, a single disk stripe per object, and a thin-provisioned virtual disk.__
-
   __Note: Here you don't need to create vmdk it is created for you.__
   1. Create Storage Class.
 
@@ -429,6 +394,9 @@
       ```
 
       [Download example](vsphere-volume-sc-vsancapabilities-with-datastore.yaml?raw=true)
+
+      __Note: If you do not apply a storage policy during dynamic provisioning on a VSAN datastore, it will use a default Virtual SAN policy with one number of failures to tolerate, a single disk stripe per object, and a thin-provisioned virtual disk.__
+
       Creating the storageclass:
 
       ``` bash

--- a/examples/volumes/vsphere/README.md
+++ b/examples/volumes/vsphere/README.md
@@ -5,7 +5,7 @@
     - [Volumes](#volumes)
     - [Persistent Volumes](#persistent-volumes)
     - [Storage Class](#storage-class)
-    - [Virtual SAN policy support inside Kubernetes] (#virtual-san-policy-support-inside-kubernetes)
+    - [Virtual SAN policy support inside Kubernetes](#virtual-san-policy-support-inside-kubernetes)
 
 ## Prerequisites
 
@@ -358,7 +358,7 @@
 
   Vsphere Infrastructure(VI) Admins will have the ability to specify custom Virtual SAN Storage Capabilities during dynamic volume provisioning. You can now define storage requirements, such as performance and availability, in the form of storage capabilities during dynamic volume provisioning. The storage capability requirements are converted into a Virtual SAN policy which are then pushed down to the Virtual SAN layer when a persistent volume (virtual disk) is being created. The virtual disk is distributed across the Virtual SAN datastore to meet the requirements.
   
-  The official [VSAN policy documentation] (https://pubs.vmware.com/vsphere-65/index.jsp?topic=%2Fcom.vmware.vsphere.virtualsan.doc%2FGUID-08911FD3-2462-4C1C-AE81-0D4DBC8F7990.html) describes in detail about each of the individual storage capabilities that are supported by VSAN. The user can specify these storage capabilities as part of storage class defintion based on his application needs.
+  The official [VSAN policy documentation](https://pubs.vmware.com/vsphere-65/index.jsp?topic=%2Fcom.vmware.vsphere.virtualsan.doc%2FGUID-08911FD3-2462-4C1C-AE81-0D4DBC8F7990.html) describes in detail about each of the individual storage capabilities that are supported by VSAN. The user can specify these storage capabilities as part of storage class defintion based on his application needs.
 
   The policy settings can be one or more of the following:
 
@@ -385,10 +385,10 @@
           hostFailuresToTolerate: "2"
           cachereservation: "20"
       ```
-      Here a persistent volume will be created with the Virtual SAN capabilities - hostFailuresToTolerate to 2 and cachereservation is 20% read cache reserved for storage object. Also the persistent volume will be zeroedthick disk.
-      The official [VSAN policy documentation] (https://pubs.vmware.com/vsphere-65/index.jsp?topic=%2Fcom.vmware.vsphere.virtualsan.doc%2FGUID-08911FD3-2462-4C1C-AE81-0D4DBC8F7990.html) describes in detail about each of the individual storage capabilities that are supported by VSAN and can be configured on the virtual disk.
-
       [Download example](vsphere-volume-sc-vsancapabilities.yaml?raw=true)
+
+      Here a persistent volume will be created with the Virtual SAN capabilities - hostFailuresToTolerate to 2 and cachereservation is 20% read cache reserved for storage object. Also the persistent volume will be zeroedthick disk.
+      The official [VSAN policy documentation](https://pubs.vmware.com/vsphere-65/index.jsp?topic=%2Fcom.vmware.vsphere.virtualsan.doc%2FGUID-08911FD3-2462-4C1C-AE81-0D4DBC8F7990.html) describes in detail about each of the individual storage capabilities that are supported by VSAN and can be configured on the virtual disk.
 
       You can also specify the datastore in the Storageclass as shown in example 2. The volume will be created on the datastore specified in the storage class.
       This field is optional. If not specified as shown in example 1, the volume will be created on the datastore specified in the vsphere config file used to initialize the vSphere Cloud Provider.

--- a/examples/volumes/vsphere/README.md
+++ b/examples/volumes/vsphere/README.md
@@ -5,6 +5,7 @@
     - [Volumes](#volumes)
     - [Persistent Volumes](#persistent-volumes)
     - [Storage Class](#storage-class)
+    - [Virtual SAN policy support inside Kubernetes] (#virtual-san-policy-support-inside-kubernetes)
 
 ## Prerequisites
 
@@ -353,6 +354,200 @@
       pvpod       1/1     Running   0          48m        
       ```
 
+### Virtual SAN policy support inside Kubernetes
+####About Virtual SAN Storage Policies####
+  Virtual SAN Storage Polices define storage requirements, such as performance and availability for your virtual machines. These policies determine how the virtual machine storage objects are provisioned and allocated within the datastore to guarantee the required level of service. When you enable Virtual SAN on a host cluster, a single Virtual SAN datastore is created and a default storage policy is assigned to the datastore.
+
+  A storage capability is typically represented by a key-value pair, where the key is a specific property that the datastore can offer and the value is a metric that the datastore guarantees for a provisioned object, such as a virtual machine metadata object or a virtual disk. When you know the storage requirements of your virtual machines, you can create a storage policy referencing capabilities that the datastore advertises. You can create several policies to capture different types or classes of requirements.
+
+####Using Virtual SAN Storage Capabilities for storage volume provisioning for containers inside Kubernetes###
+  Since Virtual SAN is one of the supported vSphere Storage backends with the vSphere cloud provider, VI Admins will also have the ability to specify custom Virtual SAN Storage Capabilities during dynamic volume provisioning. Inturn these Virtual SAN Policies are assigned to underlying virtual disk. Thus, vSphere Cloud Provider enables policy driven dynamic provisioning of kubernetes persistent volumes. It exposes data services offered by the underlying storage platform such as Virtual SAN at granularity of container volumes and provides applications a complete abstraction of storage infrastructure.
+
+  Below is list of all Virtual SAN storage capabilties supported for storage volume provisioning:
+  * `hostFailuresToTolerate`
+    * Defines the number of host, disk, or network failures a storage object can tolerate. When the fault tolerance method is mirroring: to tolerate "n" failures, "n+1" copies of the object are created and "2n+1" hosts contributing storage are required (if fault domains are configured, "2n+1" fault domains with hosts contributing storage are required). When the fault tolerance method is erasure coding: to tolerate 1 failure, 4 hosts (or fault domains) are required; and to tolerate 2 failures, 6 hosts (or fault domains) are required. Note: A host which is not part of a fault domain is counted as its own single-host fault domain.
+    * Default value: 1, Maximum value: 3.
+
+  * `cacheReservation`
+    * Flash capacity reserved as read cache for the storage object. Specified as a percentage of the logical size of the object. To be used only for addressing read performance issues. Reserved flash capacity cannot be used by other objects. Unreserved flash is shared fairly among all objects. It is specified in parts per million.
+    * This value is expressed in percentage. Default value: 0, Maximum value: 100.
+
+  * `diskStripes`
+    * The number of HDDs across which each replica of storage object is striped. A value higher than 1 may result in better performance (for e.g when flash read cache misses need to get serviced from HDD), but also results in higher used of system resources. 
+    * Default value: 1, Maximum value: 12.
+
+  * `objectSpaceReservation`
+    * Percentage of the logical size of the storage object that will be reserved (thick provisioning) upon VM provisioning. The rest of the storage object is thin provisioned. 
+    * This value is expressed in percentage. Default value: 0, Maximum value: 100.
+
+  * `iopsLimit`
+    * Defines upper IOPS limit for a disk. IO rate that has been serviced on a disk will be measured and if the rate exceeds the IOPS limit, IO will be delayed to keep it under the limit. Zero value means no limit.
+    * Default value: 0.
+
+  * `forceProvisioning`
+    * If this option is "1" the object will be provisioned even if the policy specified in the storage policy is not satisfiable with the resources currently available in the cluster. Virtual SAN will try to bring the object into compliance if and when resources become available.
+    * Value can be either O or 1.
+
+  __Note: If you do not apply a storage policy during dynamic provisioning on a VSAN datastore, it will use a default Virtual SAN policy with one number of failures to tolerate, a single disk stripe per object, and a thin-provisioned virtual disk.__
+
+  __Note: Here you don't need to create vmdk it is created for you.__
+  1. Create Storage Class.
+
+      Example 1:
+
+      ```yaml
+      kind: StorageClass
+      apiVersion: storage.k8s.io/v1beta1
+      metadata:
+        name: fast
+      provisioner: kubernetes.io/vsphere-volume
+      parameters:
+          diskformat: zeroedthick
+          hostFailuresToTolerate: "2"
+          cachereservation: "20"
+      ```
+      Here a vmdk will be created with the Virtual SAN capabilities - hostFailuresToTolerate to 2 and cachereservation is 20% read cache reserved for storage object. Also the vmdk will be zeroedthick disk.
+
+      [Download example](vsphere-volume-sc-vsancapabilities.yaml?raw=true)
+
+      You can also specify the datastore in the Storageclass as shown in example 2. The volume will be created on the datastore specified in the storage class.
+      This field is optional. If not specified as shown in example 1, the volume will be created on the datastore specified in the vsphere config file used to initialize the vSphere Cloud Provider.
+
+      Example 2:
+ 
+      ```yaml
+      kind: StorageClass
+      apiVersion: storage.k8s.io/v1beta1
+      metadata:
+        name: fast
+      provisioner: kubernetes.io/vsphere-volume
+      parameters:
+          diskformat: zeroedthick
+          datastore: VSANDatastore
+          hostFailuresToTolerate: "2"
+          cachereservation: "20"
+      ```
+
+      [Download example](vsphere-volume-sc-vsancapabilities-with-datastore.yaml?raw=true)
+      Creating the storageclass:
+
+      ``` bash
+      $ kubectl create -f examples/volumes/vsphere/vsphere-volume-sc-fast.yaml
+      ```
+
+      Verifying storage class is created:
+
+      ``` bash
+      $ kubectl describe storageclass fast 
+      Name:		fast
+      Annotations:	<none>
+      Provisioner:	kubernetes.io/vsphere-volume
+      Parameters:	diskformat=zeroedthick
+      No events.        
+      ```
+
+  2. Create Persistent Volume Claim.
+
+      See example:
+
+      ```yaml
+      kind: PersistentVolumeClaim
+      apiVersion: v1
+      metadata:
+        name: pvcsc001
+        annotations:
+          volume.beta.kubernetes.io/storage-class: fast
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 2Gi
+      ```
+
+      [Download example](vsphere-volume-pvcsc.yaml?raw=true)
+
+      Creating the persistent volume claim:
+
+      ``` bash
+      $ kubectl create -f examples/volumes/vsphere/vsphere-volume-pvcsc.yaml
+      ```
+
+      Verifying persistent volume claim is created:
+
+      ``` bash
+      $ kubectl describe pvc pvcsc001
+      Name:		pvcsc001
+      Namespace:	default
+      Status:		Bound
+      Volume:		pvc-80f7b5c1-94b6-11e6-a24f-005056a79d2d
+      Labels:		<none>
+      Capacity:	2Gi
+      Access Modes:	RWO
+      No events.
+      ```
+
+      Persistent Volume is automatically created and is bounded to this pvc.
+
+      Verifying persistent volume claim is created:
+
+      ``` bash
+      $ kubectl describe pv pvc-80f7b5c1-94b6-11e6-a24f-005056a79d2d
+      Name:		pvc-80f7b5c1-94b6-11e6-a24f-005056a79d2d
+      Labels:		<none>
+      Status:		Bound
+      Claim:		default/pvcsc001
+      Reclaim Policy:	Delete
+      Access Modes:	RWO
+      Capacity:	2Gi
+      Message:
+      Source:
+          Type:	vSphereVolume (a Persistent Disk resource in vSphere)
+          VolumePath:	[datastore1] kubevols/kubernetes-dynamic-pvc-80f7b5c1-94b6-11e6-a24f-005056a79d2d.vmdk
+          FSType:	ext4
+      No events.
+      ```
+
+      __Note: VMDK is created inside ```kubevols``` folder in datastore which is mentioned in 'vsphere' cloudprovider configuration.
+      The cloudprovider config is created during setup of Kubernetes cluster on vSphere.__
+
+  3. Create Pod which uses Persistent Volume Claim with storage class.
+
+      See example:
+
+      ```yaml
+      apiVersion: v1
+      kind: Pod
+      metadata:
+        name: pvpod
+      spec:
+        containers:
+        - name: test-container
+          image: gcr.io/google_containers/test-webserver
+          volumeMounts:
+          - name: test-volume
+            mountPath: /test-vmdk
+        volumes:
+        - name: test-volume
+          persistentVolumeClaim:
+            claimName: pvcsc001
+      ```
+
+      [Download example](vsphere-volume-pvcscpod.yaml?raw=true)
+
+      Creating the pod:
+
+      ``` bash
+      $ kubectl create -f examples/volumes/vsphere/vsphere-volume-pvcscpod.yaml
+      ```
+
+      Verifying pod is created:
+
+      ``` bash
+      $ kubectl get pod pvpod
+      NAME      READY     STATUS    RESTARTS   AGE
+      pvpod       1/1     Running   0          48m        
+      ```
 
 <!-- BEGIN MUNGE: GENERATED_ANALYTICS -->
 [![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/examples/volumes/vsphere/README.md?pixel)]()

--- a/examples/volumes/vsphere/README.md
+++ b/examples/volumes/vsphere/README.md
@@ -432,7 +432,7 @@
       Creating the storageclass:
 
       ``` bash
-      $ kubectl create -f examples/volumes/vsphere/vsphere-volume-sc-fast.yaml
+      $ kubectl create -f examples/volumes/vsphere/vsphere-volume-sc-vsancapabilities.yaml
       ```
 
       Verifying storage class is created:
@@ -442,7 +442,7 @@
       Name:		fast
       Annotations:	<none>
       Provisioner:	kubernetes.io/vsphere-volume
-      Parameters:	diskformat=zeroedthick
+      Parameters:	diskformat=zeroedthick, hostFailuresToTolerate="2", cachereservation="20"
       No events.        
       ```
 

--- a/examples/volumes/vsphere/vsphere-volume-sc-vsancapabilities-with-datastore.yaml
+++ b/examples/volumes/vsphere/vsphere-volume-sc-vsancapabilities-with-datastore.yaml
@@ -1,0 +1,10 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1beta1
+metadata:
+  name: fast
+provisioner: kubernetes.io/vsphere-volume
+parameters:
+    diskformat: zeroedthick
+    datastore: vsanDatastore
+    hostFailuresToTolerate: "2"
+    cachereservation: "20"

--- a/examples/volumes/vsphere/vsphere-volume-sc-vsancapabilities.yaml
+++ b/examples/volumes/vsphere/vsphere-volume-sc-vsancapabilities.yaml
@@ -1,0 +1,9 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1beta1
+metadata:
+  name: fast
+provisioner: kubernetes.io/vsphere-volume
+parameters:
+    diskformat: zeroedthick
+    hostFailuresToTolerate: "2"
+    cachereservation: "20"

--- a/pkg/volume/vsphere_volume/vsphere_volume_util.go
+++ b/pkg/volume/vsphere_volume/vsphere_volume_util.go
@@ -138,7 +138,7 @@ func (util *VsphereDiskUtil) CreateVolume(v *vsphereVolumeProvisioner) (vmDiskPa
 	}
 
 	vmDiskPath, err = cloud.CreateVolume(volumeOptions)
-	if err != nil || vmDiskPath == "" {
+	if err != nil {
 		glog.V(2).Infof("Error creating vsphere volume: %v", err)
 		return "", 0, err
 	}

--- a/pkg/volume/vsphere_volume/vsphere_volume_util.go
+++ b/pkg/volume/vsphere_volume/vsphere_volume_util.go
@@ -138,7 +138,7 @@ func (util *VsphereDiskUtil) CreateVolume(v *vsphereVolumeProvisioner) (vmDiskPa
 	}
 
 	vmDiskPath, err = cloud.CreateVolume(volumeOptions)
-	if err != nil {
+	if err != nil || vmDiskPath == "" {
 		glog.V(2).Infof("Error creating vsphere volume: %v", err)
 		return "", 0, err
 	}

--- a/pkg/volume/vsphere_volume/vsphere_volume_util.go
+++ b/pkg/volume/vsphere_volume/vsphere_volume_util.go
@@ -43,7 +43,7 @@ const (
 	Policy_CacheReservation       = "cachereservation"
 	Policy_DiskStripes            = "diskstripes"
 	Policy_ObjectSpaceReservation = "objectspacereservation"
-	Policy_IopsLimit              = "iopsLimit"
+	Policy_IopsLimit              = "iopslimit"
 )
 
 var ErrProbeVolume = errors.New("Error scanning attached volumes")

--- a/pkg/volume/vsphere_volume/vsphere_volume_util.go
+++ b/pkg/volume/vsphere_volume/vsphere_volume_util.go
@@ -19,6 +19,7 @@ package vsphere_volume
 import (
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -35,6 +36,14 @@ const (
 	checkSleepDuration = time.Second
 	diskByIDPath       = "/dev/disk/by-id/"
 	diskSCSIPrefix     = "wwn-0x"
+	diskformat         = "diskformat"
+
+	Policy_HostFailuresToTolerate = "hostfailurestotolerate"
+	Policy_ForceProvisioning      = "forceprovisioning"
+	Policy_CacheReservation       = "cachereservation"
+	Policy_DiskStripes            = "diskstripes"
+	Policy_ObjectSpaceReservation = "objectspacereservation"
+	Policy_IopsLimit              = "iopsLimit"
 )
 
 var ErrProbeVolume = errors.New("Error scanning attached volumes")
@@ -73,15 +82,56 @@ func (util *VsphereDiskUtil) CreateVolume(v *vsphereVolumeProvisioner) (vmDiskPa
 	// the values to the cloud provider.
 	for parameter, value := range v.options.Parameters {
 		switch strings.ToLower(parameter) {
-		case "diskformat":
+		case diskformat:
 			volumeOptions.DiskFormat = value
 		case "datastore":
 			volumeOptions.Datastore = value
+		case Policy_HostFailuresToTolerate:
+			if !validateVSANCapability(Policy_HostFailuresToTolerate, value) {
+				return "", 0, fmt.Errorf(`Invalid value for hostFailuresToTolerate in volume plugin %s. 
+				The default value is 1, minimum value is 0 and maximum value is 3.`, v.plugin.GetPluginName())
+			}
+			volumeOptions.StorageProfileData += " (\"hostFailuresToTolerate\" i" + value + ")"
+		case Policy_ForceProvisioning:
+			if !validateVSANCapability(Policy_ForceProvisioning, value) {
+				return "", 0, fmt.Errorf(`Invalid value for forceProvisioning in volume plugin %s. 
+				The value can be either 0 or 1.`, v.plugin.GetPluginName())
+			}
+			volumeOptions.StorageProfileData += " (\"forceProvisioning\" i" + value + ")"
+		case Policy_CacheReservation:
+			if !validateVSANCapability(Policy_CacheReservation, value) {
+				return "", 0, fmt.Errorf(`Invalid value for cacheReservation in volume plugin %s.
+				The minimum percentage is 0 and maximum percentage is 100.`, v.plugin.GetPluginName())
+			}
+			intVal, _ := strconv.Atoi(value)
+			volumeOptions.StorageProfileData += " (\"cacheReservation\" i" + strconv.Itoa(intVal*10000) + ")"
+		case Policy_DiskStripes:
+			if !validateVSANCapability(Policy_DiskStripes, value) {
+				return "", 0, fmt.Errorf(`Invalid value for diskStripes in volume plugin %s. 
+				The minimum value is 1 and maximum value is 12.`, v.plugin.GetPluginName())
+			}
+			volumeOptions.StorageProfileData += " (\"stripeWidth\" i" + value + ")"
+		case Policy_ObjectSpaceReservation:
+			if !validateVSANCapability(Policy_ObjectSpaceReservation, value) {
+				return "", 0, fmt.Errorf(`Invalid value for ObjectSpaceReservation in volume plugin %s. 
+				The minimum percentage is 0 and maximum percentage is 100.`, v.plugin.GetPluginName())
+			}
+			volumeOptions.StorageProfileData += " (\"proportionalCapacity\" i" + value + ")"
+		case Policy_IopsLimit:
+			if !validateVSANCapability(Policy_IopsLimit, value) {
+				return "", 0, fmt.Errorf(`Invalid value for iopsLimit in volume plugin %s. 
+				The value should be greater than 0.`, v.plugin.GetPluginName())
+			}
+			volumeOptions.StorageProfileData += " (\"iopsLimit\" i" + value + ")"
 		default:
 			return "", 0, fmt.Errorf("invalid option %q for volume plugin %s", parameter, v.plugin.GetPluginName())
 		}
 	}
 
+	if volumeOptions.StorageProfileData != "" {
+		volumeOptions.StorageProfileData = "(" + volumeOptions.StorageProfileData + ")"
+	}
+	glog.V(1).Infof("StorageProfileData in vsphere volume %q", volumeOptions.StorageProfileData)
 	// TODO: implement PVC.Selector parsing
 	if v.options.PVC.Spec.Selector != nil {
 		return "", 0, fmt.Errorf("claim.Spec.Selector is not supported for dynamic provisioning on vSphere")
@@ -131,4 +181,51 @@ func getCloudProvider(cloud cloudprovider.Interface) (*vsphere.VSphere, error) {
 		return nil, errors.New("Invalid cloud provider: expected vSphere")
 	}
 	return vs, nil
+}
+
+// Validate the capability requirement for the user specified policy attributes.
+func validateVSANCapability(capabilityName string, capabilityValue string) bool {
+	switch strings.ToLower(capabilityName) {
+	case Policy_HostFailuresToTolerate:
+		capabilityIntVal, ok := verifyCapabilityValueIsInteger(capabilityValue)
+		if ok && (capabilityIntVal >= 0 && capabilityIntVal <= 3) {
+			return true
+		}
+	case Policy_ForceProvisioning:
+		capabilityIntVal, ok := verifyCapabilityValueIsInteger(capabilityValue)
+		if ok && (capabilityIntVal == 0 || capabilityIntVal == 1) {
+			return true
+		}
+	case Policy_CacheReservation:
+		capabilityIntVal, ok := verifyCapabilityValueIsInteger(capabilityValue)
+		if ok && (capabilityIntVal >= 0 && capabilityIntVal <= 100) {
+			return true
+		}
+	case Policy_DiskStripes:
+		capabilityIntVal, ok := verifyCapabilityValueIsInteger(capabilityValue)
+		if ok && (capabilityIntVal >= 1 && capabilityIntVal <= 12) {
+			return true
+		}
+	// Need to check
+	case Policy_ObjectSpaceReservation:
+		capabilityIntVal, ok := verifyCapabilityValueIsInteger(capabilityValue)
+		if ok && (capabilityIntVal >= 0 || capabilityIntVal <= 100) {
+			return true
+		}
+	case Policy_IopsLimit:
+		capabilityIntVal, ok := verifyCapabilityValueIsInteger(capabilityValue)
+		if ok && (capabilityIntVal >= 0) {
+			return true
+		}
+	}
+	return false
+}
+
+// Verify if the capability value is of type integer.
+func verifyCapabilityValueIsInteger(capabilityValue string) (int, bool) {
+	i, err := strconv.Atoi(capabilityValue)
+	if err != nil {
+		return -1, false
+	}
+	return i, true
 }


### PR DESCRIPTION
Following test cases have been under testing:

Test cases:

1. Validation of VSAN capabilities.
- hostFailuresToTolerate : Minimum 1 and Max 3. Should be integer.
- forceProvisioning: Should be either 0 or 1 . Should be integer.
- cacheReservation: Expressed in percentage. Should be between 0 and 100. Should be integer.
- stripeWidth: Minimum is 1 and Maximum is 12. Should be integer.
- proportionalCapacity: Expressed in percentage. Should be between 0 and 100. Should be integer.
- iopsLimit: Should be greater than 0. Should be integer.

2. Use a VSAN testbed setup. Try valid VSAN capabilities which are supported by VSAN testbed. Make sure the disk is created with policy configured with it.
- Ex: Using hostFailuresToTolerate=1 and cacheReservation=12

3. Use a VSAN testbed setup. Try valid VSAN capabilities which are not supported by VSAN testbed. Make sure that the disk creation fails and PVC status is pending.

4. Use a non-VSAN testbed setup. Try using VSAN capabilities on a non-VSAN testbed. PVC status will be pending and it errors to the user saying to VSAN capabilities are not supported on a non-VSAN testbed.

5. Use a non-VSAN testbed setup. Use a normal storage class YAML without VSAN capabilities. The disk should be created successfully.

6. Try all 1 to 5 with custom datastore specified by the user.

7. Try thick, thin and eagerzeroedthick provisioning of disks. Since the code is changed for this module, this has to be tested. 