### PR TITLE
vSphere cloud provider code restructuring

### DIFF
--- a/pkg/cloudprovider/providers/vsphere/BUILD
+++ b/pkg/cloudprovider/providers/vsphere/BUILD
@@ -11,6 +11,15 @@ load(
 go_library(
     name = "go_default_library",
     srcs = [
+        "vclib/connection.go",
+        "vclib/constants.go",
+        "vclib/custom_errors.go",
+        "vclib/datacenter.go",
+        "vclib/datastore.go",
+        "vclib/pbm.go",
+        "vclib/utils.go",
+        "vclib/virtualmachine.go",
+        "vclib/volumeoptions.go",
         "vsphere.go",
         "vsphere_metrics.go",
         "vsphere_util.go",

--- a/pkg/cloudprovider/providers/vsphere/vclib/connection.go
+++ b/pkg/cloudprovider/providers/vsphere/vclib/connection.go
@@ -1,0 +1,100 @@
+package vclib
+
+import (
+	"fmt"
+	"net/url"
+	"sync"
+
+	"github.com/golang/glog"
+	"github.com/vmware/govmomi"
+	"github.com/vmware/govmomi/find"
+	"github.com/vmware/govmomi/session"
+	"github.com/vmware/govmomi/vim25"
+	"golang.org/x/net/context"
+)
+
+type VSphereConnection struct {
+	GoVmomiClient     *govmomi.Client
+	Username          string
+	Password          string
+	Hostname          string
+	Port              string
+	Insecure          bool
+	RoundTripperCount uint
+}
+
+var (
+	vsphereConnection *VSphereConnection
+	clientLock        sync.Mutex
+)
+
+// Function to make connection to vCenter Server
+// After successful connection, Client will set to govmomi client object.
+func (connection VSphereConnection) Connect() error {
+	var err error
+	clientLock.Lock()
+	defer clientLock.Unlock()
+
+	if connection.GoVmomiClient == nil {
+		connection.GoVmomiClient, err = connection.newClient()
+		if err != nil {
+			glog.Errorf("Failed to create govmomi client. err: %v", err)
+			return err
+		}
+		return nil
+	}
+	m := session.NewManager(connection.GoVmomiClient.Client)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	userSession, err := m.UserSession(ctx)
+	if err != nil {
+		glog.Errorf("Error while obtaining user session. err: %v", err)
+		return err
+	}
+	if userSession != nil {
+		return nil
+	}
+
+	glog.Warningf("Creating new client session since the existing session is not valid or not authenticated")
+	connection.GoVmomiClient.Logout(ctx)
+	connection.GoVmomiClient, err = connection.newClient()
+	if err != nil {
+		glog.Errorf("Failed to create govmomi client. err: %v", err)
+		return err
+	}
+	return nil
+}
+
+// Function to obtain DataCenter Object from given DataCenter name
+func (connection VSphereConnection) GetDataCenter(ctx context.Context, datacenterName string) (DataCenter, error) {
+	finder := find.NewFinder(vsphereConnection.GoVmomiClient.Client, true)
+	dataCenter, err := finder.Datacenter(ctx, datacenterName)
+	if err != nil {
+		glog.Errorf("Failed to find the data center: %s. err: %v", datacenterName, err)
+		return nil, err
+	}
+	dc := DataCenter{dataCenter}
+	return dc, nil
+}
+
+// Private function to create client object, called from VSphereConnection. Connect()
+func (connection VSphereConnection) newClient() (*govmomi.Client, error) {
+	url, err := url.Parse(fmt.Sprintf("https://%s/sdk", connection.Hostname))
+	if err != nil {
+		glog.Errorf("Failed to parse URL: %s. err: %v", url, err)
+		return nil, err
+	}
+	url.User = url.UserPassword(connection.Username, connection.Password)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	client, err := govmomi.NewClient(ctx, url, connection.Insecure)
+	if err != nil {
+		glog.Errorf("Failed to create new client. err: %v", err)
+		return nil, err
+	}
+	if connection.RoundTripperCount == 0 {
+		connection.RoundTripperCount = RoundTripperDefaultCount
+	}
+	client.RoundTripper = vim25.Retry(client.RoundTripper, vim25.TemporaryNetworkError(int(connection.RoundTripperCount)))
+	return client, nil
+}

--- a/pkg/cloudprovider/providers/vsphere/vclib/constants.go
+++ b/pkg/cloudprovider/providers/vsphere/vclib/constants.go
@@ -1,0 +1,38 @@
+package vclib
+
+const (
+	LOG_LEVEL = 4
+)
+const (
+	RoundTripperDefaultCount = 3
+	VSANDatastoreType        = "vsan"
+)
+
+// Volume Constnts
+const (
+	ThinDiskType             = "thin"
+	PreallocatedDiskType     = "preallocated"
+	EagerZeroedThickDiskType = "eagerZeroedThick"
+	ZeroedThickDiskType      = "zeroedThick"
+)
+
+// Controller Constants
+const (
+	SCSIControllerLimit       = 4
+	SCSIControllerDeviceLimit = 15
+	SCSIDeviceSlots           = 16
+	SCSIReservedSlot          = 7
+
+	SCSIControllerType        = "scsi"
+	LSILogicControllerType    = "lsiLogic"
+	BusLogicControllerType    = "busLogic"
+	LSILogicSASControllerType = "lsiLogic-sas"
+	PVSCSIControllerType      = "pvscsi"
+)
+
+const (
+	DatastoreProperty     = "datastore"
+	DatastoreInfoProperty = "info"
+	VirtualMachineType    = "VirtualMachine"
+	_
+)

--- a/pkg/cloudprovider/providers/vsphere/vclib/custom_errors.go
+++ b/pkg/cloudprovider/providers/vsphere/vclib/custom_errors.go
@@ -1,0 +1,19 @@
+package vclib
+
+import "errors"
+
+const (
+	FileAlreadyExistErrMsg     = "File requested already exist"
+	NoDiskUUIDFoundErrMsg      = "No disk UUID found"
+	NoDevicesFoundErrMsg       = "No devices found"
+	DiskNotFoundErrMsg         = "No vSphere disk ID found"
+	InvalidVolumeOptionsErrMsg = "VolumeOptions verification failed"
+)
+
+var (
+	ErrFileAlreadyExist     = errors.New(FileAlreadyExistErrMsg)
+	ErrNoDiskUUIDFound      = errors.New(NoDiskUUIDFoundErrMsg)
+	ErrNoDevicesFound       = errors.New(NoDevicesFoundErrMsg)
+	ErrNoDiskIDFound        = errors.New(DiskNotFoundErrMsg)
+	ErrInvalidVolumeOptions = errors.New(InvalidVolumeOptionsErrMsg)
+)

--- a/pkg/cloudprovider/providers/vsphere/vclib/datacenter.go
+++ b/pkg/cloudprovider/providers/vsphere/vclib/datacenter.go
@@ -1,0 +1,81 @@
+package vclib
+
+import (
+	"errors"
+	"strings"
+
+	"fmt"
+	"github.com/golang/glog"
+	"github.com/vmware/govmomi/object"
+	"golang.org/x/net/context"
+)
+
+type DataCenter struct {
+	*object.Datacenter
+}
+
+// find and return VM for the given VM UUID
+func (dc DataCenter) GetVMByUUID(ctx context.Context, vmUUID string) (VirtualMachine, error) {
+	s := object.NewSearchIndex(dc.Client())
+	vmUUID = strings.ToLower(strings.TrimSpace(vmUUID))
+	svm, err := s.FindByUuid(ctx, dc.Datacenter, vmUUID, true, nil)
+	if err != nil {
+		glog.Errorf("Failed to find VM by UUID. VM UUID: %s, err: %v", vmUUID, err)
+		return nil, err
+	}
+	virtualMachine := VirtualMachine{object.NewVirtualMachine(dc.Client(), svm.Reference())}
+	return virtualMachine, nil
+}
+
+// Returns VM located at vmpath - VMPath should have folder path and VM Name
+func (dc DataCenter) GetVMByPath(ctx context.Context, vmpath string) (VirtualMachine, error) {
+	finder := getFinder(dc)
+	vm, err := finder.VirtualMachine(ctx, vmpath)
+	if err != nil {
+		glog.Errorf("Failed to find VM by Path. VM Path: %s, err: %v", vmpath, err)
+		return nil, err
+	}
+	virtualMachine := VirtualMachine{vm}
+	return virtualMachine, nil
+}
+
+// Return datastore for given VM Disk
+func (dc DataCenter) GetDataStoreByPath(ctx context.Context, vmDiskPath string) (DataStore, error) {
+	datastorePathObj := new(object.DatastorePath)
+	isSuccess := datastorePathObj.FromString(vmDiskPath)
+	if !isSuccess {
+		glog.Errorf("Failed to parse vmDiskPath: %s", vmDiskPath)
+		return nil, errors.New("Failed to parse vmDiskPath")
+	}
+	finder := getFinder(dc)
+	ds, err := finder.Datastore(ctx, datastorePathObj.Datastore)
+	if err != nil {
+		glog.Errorf("Failed while searching for datastore: %s. err: %v", datastorePathObj.Datastore, err)
+		return nil, err
+	}
+	datastore := DataStore{ds}
+	return datastore, nil
+}
+
+// Return Datastore object for the given datastore name
+func (dc DataCenter) GetDataStoreByName(ctx context.Context, name string) (DataStore, error) {
+	finder := getFinder(dc)
+	ds, err := finder.Datastore(ctx, name)
+	if err != nil {
+		glog.Errorf("Failed while searching for datastore: %s. err %v", name, err)
+		return nil, err
+	}
+	datastore := DataStore{ds}
+	return datastore, nil
+}
+
+// Get the folder reference for the given folder name.
+func (dc DataCenter) GetFolder(ctx context.Context, folderName string) (*object.Folder, error) {
+	finder := getFinder(dc)
+	vmFolder, err := finder.Folder(ctx, strings.TrimSuffix(folderName, "/"))
+	if err != nil {
+		glog.Errorf("Failed to get the folder reference for %s with err: %v", folderName, err)
+		return nil, fmt.Errorf("Failed to get the folder reference for %s with err: %v", folderName, err)
+	}
+	return vmFolder, nil
+}

--- a/pkg/cloudprovider/providers/vsphere/vclib/datastore.go
+++ b/pkg/cloudprovider/providers/vsphere/vclib/datastore.go
@@ -1,0 +1,140 @@
+package vclib
+
+import (
+	"github.com/golang/glog"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/property"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/soap"
+	"github.com/vmware/govmomi/vim25/types"
+	"golang.org/x/net/context"
+)
+
+type DataStore struct {
+	*object.Datastore
+}
+
+// Creates a directory using the specified name. If the intermediate level folders do not exist,
+// and the parameter createParents is true, all the non-existent folders are created.
+func (ds DataStore) CreateDirectory(ctx context.Context, directoryPath string, createParents bool) error {
+	fileManager := object.NewFileManager(ds.Client())
+	err := fileManager.MakeDirectory(ctx, directoryPath, nil, createParents)
+	if err != nil {
+		glog.Errorf("Cannot create dir: %s. err: %v", directoryPath, err)
+		if soap.IsSoapFault(err) {
+			soapFault := soap.ToSoapFault(err)
+			if _, ok := soapFault.VimFault().(types.FileAlreadyExists); ok {
+				return ErrFileAlreadyExist
+			}
+		}
+		return err
+	}
+	glog.V(LOG_LEVEL).Infof("Created dir with path as %+q", directoryPath)
+	return nil
+}
+
+// Create a virtual disk at given diskPath using specified values in the volumeOptions object
+func (ds DataStore) CreateVirtualDisk(ctx context.Context, diskPath string, volumeOptions VolumeOptions) (err error) {
+	if !volumeOptions.VerifyVolumeOptions() {
+		glog.Error("VolumeOptions verification failed")
+		return ErrInvalidVolumeOptions
+	}
+	// Create virtual disk
+	diskFormat := diskFormatValidType[volumeOptions.DiskFormat]
+	// Create a virtual disk manager
+	virtualDiskManager := object.NewVirtualDiskManager(ds.Client())
+	// Create specification for new virtual disk
+	vmDiskSpec := &types.FileBackedVirtualDiskSpec{
+		VirtualDiskSpec: types.VirtualDiskSpec{
+			AdapterType: LSILogicControllerType,
+			DiskType:    diskFormat,
+		},
+		CapacityKb: int64(volumeOptions.CapacityKB),
+	}
+	task, err := virtualDiskManager.CreateVirtualDisk(ctx, diskPath, nil, vmDiskSpec)
+	if err != nil {
+		glog.Errorf("Failed to create virtual disk: %s. err %v", diskPath, err)
+		return err
+	}
+	return task.Wait(ctx)
+}
+
+// Creates a virtual disk with the policy configured to the disk.
+// A call to this function is made only when a user specifies VSAN storage capabilties in the storage class definition.
+func (ds DataStore) CreateVirtualDiskWithPolicy(ctx context.Context, diskPath string, virtualMachine VirtualMachine, diskControllerType string, volumeOptions VolumeOptions) error {
+
+	disk, _, err := CreateDiskSpec(ctx, virtualMachine, ds.Reference(), diskPath, diskControllerType, volumeOptions)
+	if err != nil {
+		glog.Errorf("Failed to create Disk Spec. err: %v", err)
+		return err
+	}
+	// Reconfigure VM
+	virtualMachineConfigSpec := types.VirtualMachineConfigSpec{}
+	deviceConfigSpec := &types.VirtualDeviceConfigSpec{
+		Device:        disk,
+		Operation:     types.VirtualDeviceConfigSpecOperationAdd,
+		FileOperation: types.VirtualDeviceConfigSpecFileOperationCreate,
+	}
+	storageProfileSpec := &types.VirtualMachineDefinedProfileSpec{}
+	// Is PBM storage policy ID is present, set the storage spec profile ID,
+	// else, set raw the VSAN policy string.
+	if volumeOptions.StoragePolicyID != "" {
+		storageProfileSpec.ProfileId = volumeOptions.StoragePolicyID
+	} else if volumeOptions.VSANStorageProfileData != "" {
+		storageProfileSpec.ProfileId = ""
+		storageProfileSpec.ProfileData = &types.VirtualMachineProfileRawData{
+			ExtensionKey: "com.vmware.vim.sps",
+			ObjectData:   volumeOptions.VSANStorageProfileData,
+		}
+	}
+	deviceConfigSpec.Profile = append(deviceConfigSpec.Profile, storageProfileSpec)
+	virtualMachineConfigSpec.DeviceChange = append(virtualMachineConfigSpec.DeviceChange, deviceConfigSpec)
+	task, err := virtualMachine.Reconfigure(ctx, virtualMachineConfigSpec)
+	if err != nil {
+		glog.Errorf("Failed to reconfigure the VM with the disk with err - %v.", err)
+		return err
+	}
+	err = task.Wait(ctx)
+	if err != nil {
+		glog.Errorf("Failed to reconfigure the VM with the disk with err - %v.", err)
+		return err
+	}
+	return nil
+}
+
+//  Deletes a disk at given disk path.
+func (ds DataStore) DeleteVolume(ctx context.Context, diskPath string) error {
+	// Create a virtual disk manager
+	virtualDiskManager := object.NewVirtualDiskManager(ds.Client())
+
+	// Delete virtual disk
+	task, err := virtualDiskManager.DeleteVirtualDisk(ctx, diskPath, nil)
+	if err != nil {
+		glog.Errorf("Failed to delete virtual disk. err: %v", err)
+		return err
+	}
+	return task.Wait(ctx)
+}
+
+// Check the Datastore object is of the type VSAN
+func (ds DataStore) IsVSANDatastore(ctx context.Context) (bool, error) {
+	pc := property.DefaultCollector(ds.Client())
+
+	// Convert datastores into list of references
+	var dsRefs []types.ManagedObjectReference
+	dsRefs = append(dsRefs, ds.Reference())
+
+	// Retrieve summary property for the given datastore
+	var dsMorefs []mo.Datastore
+	err := pc.Retrieve(ctx, dsRefs, []string{"summary"}, &dsMorefs)
+	if err != nil {
+		glog.Errorf("Failed to retrieve datastore summary property. err: %v", err)
+		return false, err
+	}
+	for _, ds := range dsMorefs {
+		if ds.Summary.Type == VSANDatastoreType {
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/pkg/cloudprovider/providers/vsphere/vclib/pbm.go
+++ b/pkg/cloudprovider/providers/vsphere/vclib/pbm.go
@@ -1,0 +1,104 @@
+package vclib
+
+import (
+	"fmt"
+
+	"github.com/golang/glog"
+	"github.com/vmware/govmomi"
+	"github.com/vmware/govmomi/pbm"
+	"github.com/vmware/govmomi/property"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+	"golang.org/x/net/context"
+
+	pbmtypes "github.com/vmware/govmomi/pbm/types"
+)
+
+type PbmClient struct {
+	*pbm.Client
+	connection VSphereConnection
+}
+
+func (pbmClient *PbmClient) NewPbmClient(ctx context.Context, connection VSphereConnection) error {
+	connection.Connect()
+	client, err := pbm.NewClient(ctx, connection.GoVmomiClient.Client)
+	if err != nil {
+		glog.Errorf("Failed to create new Pbm Client. err: %v", err)
+		return err
+	}
+	pbmClient.Client = client
+	pbmClient.connection = connection
+	return nil
+}
+
+// Get placement compatibility result based on storage policy requirements.
+func (pbmClient *PbmClient) GetPlacementCompatibilityResult(ctx context.Context, storagePolicyID string, datastores []types.ManagedObjectReference) (pbm.PlacementCompatibilityResult, error) {
+	var hubs []pbmtypes.PbmPlacementHub
+	for _, ds := range datastores {
+		hubs = append(hubs, pbmtypes.PbmPlacementHub{
+			HubType: ds.Type,
+			HubId:   ds.Value,
+		})
+	}
+	req := []pbmtypes.BasePbmPlacementRequirement{
+		&pbmtypes.PbmPlacementCapabilityProfileRequirement{
+			ProfileId: pbmtypes.PbmProfileId{
+				UniqueId: storagePolicyID,
+			},
+		},
+	}
+	res, err := pbmClient.CheckRequirements(ctx, hubs, nil, req)
+	if err != nil {
+		glog.Errorf("Error occurred for CheckRequirements call. err %v", err)
+		return nil, err
+	}
+	return res, nil
+}
+
+func (pbmClient *PbmClient) GetCompatibleDatastoresMo(ctx context.Context, compatibilityResult pbm.PlacementCompatibilityResult) ([]mo.Datastore, error) {
+	compatibleHubs := compatibilityResult.CompatibleDatastores()
+	// Return an error if there are no compatible datastores.
+	if len(compatibleHubs) < 1 {
+		glog.Errorf("There are no compatible datastores that satisfy the storage policy requirements")
+		return nil, fmt.Errorf("There are no compatible datastores that satisfy the storage policy requirements")
+	}
+	dsMoList, err := getDatastoreMo(ctx, pbmClient.connection.GoVmomiClient, compatibleHubs)
+	if err != nil {
+		glog.Errorf("Failed to get datastore managed objects for compatible hubs. err %v", err)
+		return nil, err
+	}
+	return dsMoList, nil
+}
+
+func (pbmClient *PbmClient) GetNonCompatibleDatastoresMo(ctx context.Context, compatibilityResult pbm.PlacementCompatibilityResult) []mo.Datastore {
+	nonCompatibleHubs := compatibilityResult.NonCompatibleDatastores()
+	// Return an error if there are no compatible datastores.
+	if len(nonCompatibleHubs) < 1 {
+		return nil
+	}
+	dsMoList, err := getDatastoreMo(ctx, pbmClient.connection.GoVmomiClient, nonCompatibleHubs)
+	if err != nil {
+		glog.Errorf("Failed to get datastore managed objects for non-compatible hubs. err %v", err)
+		return nil
+	}
+	return dsMoList
+}
+
+// Get the datastore managed objects for the placement hubs using property collector.
+func getDatastoreMo(ctx context.Context, govmomiClient *govmomi.Client, hubs []pbmtypes.PbmPlacementHub) ([]mo.Datastore, error) {
+	var dsMoRefs []types.ManagedObjectReference
+	for _, hub := range hubs {
+		dsMoRefs = append(dsMoRefs, types.ManagedObjectReference{
+			Type:  hub.HubType,
+			Value: hub.HubId,
+		})
+	}
+	pc := property.DefaultCollector(govmomiClient.Client)
+	var dsMoList []mo.Datastore
+	err := pc.Retrieve(ctx, dsMoRefs, []string{DatastoreInfoProperty}, &dsMoList)
+	if err != nil {
+		glog.Errorf("Failed to get datastore managed objects for placement hubs. err: %v", err)
+		return nil, err
+	}
+	return dsMoList, nil
+}

--- a/pkg/cloudprovider/providers/vsphere/vclib/utils.go
+++ b/pkg/cloudprovider/providers/vsphere/vclib/utils.go
@@ -1,0 +1,243 @@
+package vclib
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/golang/glog"
+	"github.com/vmware/govmomi"
+	"github.com/vmware/govmomi/find"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/property"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+	"golang.org/x/net/context"
+)
+
+// Create a Dummy VM at specified location with given name.
+func CreateDummyVM(ctx context.Context, datacenter DataCenter, datastore DataStore, pool *object.ResourcePool, foldername string, vmName string) (VirtualMachine, error) {
+	// Create a virtual machine config spec with 1 SCSI adapter.
+	virtualMachineConfigSpec := types.VirtualMachineConfigSpec{
+		Name: vmName,
+		Files: &types.VirtualMachineFileInfo{
+			VmPathName: "[" + datastore.Name() + "]",
+		},
+		NumCPUs:  1,
+		MemoryMB: 4,
+		DeviceChange: []types.BaseVirtualDeviceConfigSpec{
+			&types.VirtualDeviceConfigSpec{
+				Operation: types.VirtualDeviceConfigSpecOperationAdd,
+				Device: &types.ParaVirtualSCSIController{
+					VirtualSCSIController: types.VirtualSCSIController{
+						SharedBus: types.VirtualSCSISharingNoSharing,
+						VirtualController: types.VirtualController{
+							BusNumber: 0,
+							VirtualDevice: types.VirtualDevice{
+								Key: 1000,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	// Get the folder reference for global working directory where the dummy VM needs to be created.
+	vmFolder, err := datacenter.GetFolder(ctx, foldername)
+	if err != nil {
+		glog.Errorf("Failed to get the folder reference for %s with err: %v", foldername, err)
+		return nil, fmt.Errorf("Failed to get the folder reference for %q with err: %+v", foldername, err)
+	}
+
+	task, err := vmFolder.CreateVM(ctx, virtualMachineConfigSpec, pool, nil)
+	if err != nil {
+		glog.Errorf("Failed to create VM. err: %v", err)
+		return nil, err
+	}
+
+	dummyVMTaskInfo, err := task.WaitForResult(ctx, nil)
+	if err != nil {
+		glog.Errorf("Error occurred while waiting for create VM task result. err: %v", err)
+		return nil, err
+	}
+
+	vmRef := dummyVMTaskInfo.Result.(object.Reference)
+	dummyVM := object.NewVirtualMachine(datacenter.Client(), vmRef.Reference())
+	return VirtualMachine{dummyVM}, nil
+}
+
+func getFinder(dc DataCenter) *find.Finder {
+	finder := find.NewFinder(dc.Client(), true)
+	finder.SetDatacenter(dc.Datacenter)
+	return finder
+}
+
+func CreateDiskSpec(ctx context.Context, vm VirtualMachine, datastoreMoRef types.ManagedObjectReference, diskPath string, diskControllerType string, volumeOptions VolumeOptions) (disk *types.VirtualDisk, newSCSIController types.BaseVirtualDevice, err error) {
+	vmDevices, err := vm.Device(ctx)
+	if err != nil {
+		glog.Errorf("Failed to retrieve VM devices. err: %v", err)
+		return
+	}
+	// find SCSI controller of particular type from VM devices
+	scsiControllersOfRequiredType := getSCSIControllersOfType(vmDevices, diskControllerType)
+	scsiController := getAvailableSCSIController(scsiControllersOfRequiredType)
+	if scsiController == nil {
+		newSCSIController, err = vm.CreateAndAttachSCSIController(ctx, diskControllerType)
+		if err != nil {
+			glog.Errorf("Failed to create SCSI controller for VM :%q with err: %+v", vm.Name(), err)
+			return
+		}
+
+		// Get VM device list
+		vmDevices, err := vm.Device(ctx)
+		if err != nil {
+			glog.Errorf("Failed to retrieve VM devices. err: %v", err)
+			return
+		}
+
+		// verify scsi controller in virtual machine
+		scsiControllersOfRequiredType := getSCSIControllersOfType(vmDevices, diskControllerType)
+		scsiController := getAvailableSCSIController(scsiControllersOfRequiredType)
+		if scsiController == nil {
+			glog.Errorf("cannot find SCSI controller in VM")
+			// attempt clean up of scsi controller
+			vm.DeleteController(ctx, newSCSIController)
+			err = fmt.Errorf("cannot find SCSI controller in VM")
+			return
+		}
+	}
+	disk = vmDevices.CreateDisk(scsiController, datastoreMoRef, diskPath)
+	unitNumber, err := getNextUnitNumber(vmDevices, scsiController)
+	if err != nil {
+		glog.Errorf("cannot attach disk to VM, limit reached - %v.", err)
+		return
+	}
+	*disk.UnitNumber = unitNumber
+	backing := disk.Backing.(*types.VirtualDiskFlatVer2BackingInfo)
+	backing.DiskMode = string(types.VirtualDiskModeIndependent_persistent)
+
+	if volumeOptions.CapacityKB != 0 {
+		disk.CapacityInKB = int64(volumeOptions.CapacityKB)
+	}
+	disk.CapacityInKB = int64(volumeOptions.CapacityKB)
+	if volumeOptions.DiskFormat != "" {
+		var diskFormat string
+		diskFormat = diskFormatValidType[volumeOptions.DiskFormat]
+		switch diskFormat {
+		case ThinDiskType:
+			backing.ThinProvisioned = types.NewBool(true)
+		case EagerZeroedThickDiskType:
+			backing.EagerlyScrub = types.NewBool(true)
+		default:
+			backing.ThinProvisioned = types.NewBool(false)
+		}
+	}
+	return
+}
+
+// Filter Specific type of Controller device from given list of Virtual Machine Devices
+func getSCSIControllersOfType(vmDevices object.VirtualDeviceList, scsiType string) []*types.VirtualController {
+	// get virtual scsi controllers of passed argument type
+	var scsiControllers []*types.VirtualController
+	for _, device := range vmDevices {
+		devType := vmDevices.Type(device)
+		if devType == scsiType {
+			if c, ok := device.(types.BaseVirtualController); ok {
+				scsiControllers = append(scsiControllers, c.GetVirtualController())
+			}
+		}
+	}
+	return scsiControllers
+}
+
+// Filter and return list of Controller Devices from given list of Virtual Machine Devices.
+func getSCSIControllers(vmDevices object.VirtualDeviceList) []*types.VirtualController {
+	// get all virtual scsi controllers
+	var scsiControllers []*types.VirtualController
+	for _, device := range vmDevices {
+		devType := vmDevices.Type(device)
+		switch devType {
+		case SCSIControllerType, strings.ToLower(LSILogicControllerType), strings.ToLower(BusLogicControllerType), PVSCSIControllerType, strings.ToLower(LSILogicSASControllerType):
+			if c, ok := device.(types.BaseVirtualController); ok {
+				scsiControllers = append(scsiControllers, c.GetVirtualController())
+			}
+		}
+	}
+	return scsiControllers
+}
+
+// Return available SCSI Controller from list of given controllers, which has less than 15 disk devices.
+func getAvailableSCSIController(scsiControllers []*types.VirtualController) *types.VirtualController {
+	// get SCSI controller which has space for adding more devices
+	for _, controller := range scsiControllers {
+		if len(controller.Device) < SCSIControllerDeviceLimit {
+			return controller
+		}
+	}
+	return nil
+}
+
+// Return formatted  VirtualDisk UUID
+func formatVirtualDiskUUID(uuid string) string {
+	uuidwithNoSpace := strings.Replace(uuid, " ", "", -1)
+	uuidWithNoHypens := strings.Replace(uuidwithNoSpace, "-", "", -1)
+	return strings.ToLower(uuidWithNoHypens)
+}
+
+// Return next available SCSI controller unit number from given list of Controller Device List
+func getNextUnitNumber(devices object.VirtualDeviceList, c types.BaseVirtualController) (int32, error) {
+	var takenUnitNumbers [SCSIDeviceSlots]bool
+	takenUnitNumbers[SCSIReservedSlot] = true
+	key := c.GetVirtualController().Key
+
+	for _, device := range devices {
+		d := device.GetVirtualDevice()
+		if d.ControllerKey == key {
+			if d.UnitNumber != nil {
+				takenUnitNumbers[*d.UnitNumber] = true
+			}
+		}
+	}
+	for unitNumber, takenUnitNumber := range takenUnitNumbers {
+		if !takenUnitNumber {
+			return int32(unitNumber), nil
+		}
+	}
+	return -1, fmt.Errorf("SCSI Controller with key=%d does not have any available slots.", key)
+}
+
+// Get the best fit compatible datastore by free space.
+func GetMostFreeDatastore(dsMo []mo.Datastore) mo.Datastore {
+	var curMax int64
+	curMax = -1
+	var index int
+	for i, ds := range dsMo {
+		dsFreeSpace := ds.Info.GetDatastoreInfo().FreeSpace
+		if dsFreeSpace > curMax {
+			curMax = dsFreeSpace
+			index = i
+		}
+	}
+	return dsMo[index]
+}
+
+// Get the VM list inside a folder.
+func GetVMsInsideFolder(ctx context.Context, vmFolder *object.Folder, client *govmomi.Client, properties []string) ([]mo.VirtualMachine, error) {
+	vmFolders, err := vmFolder.Children(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	pc := property.DefaultCollector(client.Client)
+	var vmRefs []types.ManagedObjectReference
+	var vmMoList []mo.VirtualMachine
+	for _, vmFolder := range vmFolders {
+		if vmFolder.Reference().Type == VirtualMachineType {
+			vmRefs = append(vmRefs, vmFolder.Reference())
+		}
+	}
+	err = pc.Retrieve(ctx, vmRefs, properties, &vmMoList)
+	if err != nil {
+		return nil, err
+	}
+	return vmMoList, nil
+}

--- a/pkg/cloudprovider/providers/vsphere/vclib/virtualmachine.go
+++ b/pkg/cloudprovider/providers/vsphere/vclib/virtualmachine.go
@@ -1,0 +1,326 @@
+package vclib
+
+import (
+	"fmt"
+
+	"github.com/golang/glog"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+	"golang.org/x/net/context"
+	"path/filepath"
+)
+
+type VirtualMachine struct {
+	*object.VirtualMachine
+}
+
+// Check if Disk is attached to the VM, if Yes return true else return false
+func (vm VirtualMachine) IsDiskAttached(ctx context.Context, diskPath string) (bool, error) {
+	// Get devices from VM
+	_, err := vm.GetVirtualDiskControllerKey(ctx, diskPath)
+	if err != nil {
+		if err == ErrNoDevicesFound {
+			return false, nil
+		}
+		glog.Errorf("Failed to check whether disk is attached. err: %s", err)
+		return false, err
+	}
+	return true, nil
+}
+
+// Returns the object key that denotes the controller object to which vmdk is attached.
+func (vm VirtualMachine) GetVirtualDiskControllerKey(ctx context.Context, diskPath string) (int32, error) {
+	volumeUUID, err := vm.GetVirtualDiskUUIDByPath(ctx, diskPath)
+	if err != nil {
+		glog.Errorf("disk uuid not found for %v. err: %s", diskPath, err)
+		return -1, err
+	}
+	vmDevices, err := vm.Device(ctx)
+	if err != nil {
+		return -1, err
+	}
+	// filter vm devices to retrieve disk ID for the given vmdk file
+	for _, device := range vmDevices {
+		if vmDevices.TypeName(device) == "VirtualDisk" {
+			diskUUID, _ := GetVirtualDiskUUIDByDevice(device)
+			if diskUUID == volumeUUID {
+				return device.GetVirtualDevice().ControllerKey, nil
+			}
+		}
+	}
+	return -1, ErrNoDevicesFound
+}
+
+// Returns disk UUID for a virtual disk device.
+func GetVirtualDiskUUIDByDevice(newDevice types.BaseVirtualDevice) (string, error) {
+	virtualDevice := newDevice.GetVirtualDevice()
+	if backing, ok := virtualDevice.Backing.(*types.VirtualDiskFlatVer2BackingInfo); ok {
+		uuid := formatVirtualDiskUUID(backing.Uuid)
+		return uuid, nil
+	}
+	return "", ErrNoDiskUUIDFound
+}
+
+// Return disk UUID for a virtual disk path.
+func (vm VirtualMachine) GetVirtualDiskUUIDByPath(ctx context.Context, diskPath string) (string, error) {
+	if len(diskPath) > 0 && filepath.Ext(diskPath) != ".vmdk" {
+		diskPath += ".vmdk"
+	}
+	vdm := object.NewVirtualDiskManager(vm.Client())
+	// Returns uuid of vmdk virtual disk
+	diskUUID, err := vdm.QueryVirtualDiskUuid(ctx, diskPath, nil)
+
+	if err != nil {
+		glog.Errorf("QueryVirtualDiskUuid failed for diskPath: %s, err: %v", diskPath, err)
+		return "", ErrNoDiskUUIDFound
+	}
+	diskUUID = formatVirtualDiskUUID(diskUUID)
+	return diskUUID, nil
+}
+
+// Returns a device id which is internal vSphere API identifier for the attached virtual disk.
+func (vm VirtualMachine) GetVirtualDiskID(ctx context.Context, diskPath string) (string, error) {
+	volumeUUID, err := vm.GetVirtualDiskUUIDByPath(ctx, diskPath)
+	if err != nil {
+		glog.Errorf("disk uuid not found for %v ", diskPath)
+		return "", err
+	}
+	vmDevices, err := vm.Device(ctx)
+	if err != nil {
+		return nil, err
+	}
+	// filter vm devices to retrieve disk ID for the given vmdk file
+	for _, device := range vmDevices {
+		if vmDevices.TypeName(device) == "VirtualDisk" {
+			diskUUID, _ := GetVirtualDiskUUIDByDevice(device)
+			if diskUUID == volumeUUID {
+				return vmDevices.Name(device), nil
+			}
+		}
+	}
+	return "", ErrNoDiskIDFound
+}
+
+// Delete the VM.
+func (vm VirtualMachine) DeleteVM(ctx context.Context) error {
+	destroyTask, err := vm.Destroy(ctx)
+	if err != nil {
+		return err
+	}
+	return destroyTask.Wait(ctx)
+}
+
+// Attach disk to the Virtual Machine
+func (vm VirtualMachine) AttachDisk(ctx context.Context, vmDiskPath string, storagePolicyID string, diskControllerType string, dsRef types.ManagedObjectReference) (diskID string, diskUUID string, err error) {
+	var newSCSIController types.BaseVirtualDevice
+	attached, err := vm.IsDiskAttached(ctx, vmDiskPath)
+	if err != nil {
+		glog.Errorf("Error occurred while checking disk attachment: Disk Path: %s, err: %v", vmDiskPath, err)
+		return "", "", err
+	}
+	if attached {
+		diskID, _ = vm.GetVirtualDiskID(ctx, vmDiskPath)
+		diskUUID, _ = vm.GetVirtualDiskUUIDByPath(ctx, vmDiskPath)
+		return diskID, diskUUID, nil
+	}
+
+	disk, newSCSIController, err := CreateDiskSpec(ctx, vm, dsRef, vmDiskPath, diskControllerType, VolumeOptions{})
+	if err != nil {
+		glog.Errorf("Error occurred while creating disk spec, err: %v", err)
+		return "", "", err
+	}
+	virtualMachineConfigSpec := types.VirtualMachineConfigSpec{}
+	deviceConfigSpec := &types.VirtualDeviceConfigSpec{
+		Device:    disk,
+		Operation: types.VirtualDeviceConfigSpecOperationAdd,
+	}
+
+	// Configure the disk with the SPBM profile only if ProfileID is not empty.
+	if storagePolicyID != "" {
+		profileSpec := &types.VirtualMachineDefinedProfileSpec{
+			ProfileId: storagePolicyID,
+		}
+		deviceConfigSpec.Profile = append(deviceConfigSpec.Profile, profileSpec)
+	}
+	virtualMachineConfigSpec.DeviceChange = append(virtualMachineConfigSpec.DeviceChange, deviceConfigSpec)
+	task, err := vm.Reconfigure(ctx, virtualMachineConfigSpec)
+	if err != nil {
+		glog.Errorf("Failed to attach the disk with storagePolicy: %+q with err - %v", storagePolicyID, err)
+		if newSCSIController != nil {
+			vm.DeleteController(ctx, newSCSIController)
+		}
+		return "", "", err
+	}
+	err = task.Wait(ctx)
+	if err != nil {
+		glog.Errorf("Failed to attach the disk with storagePolicy: %+q with err - %v", storagePolicyID, err)
+		if newSCSIController != nil {
+			vm.DeleteController(ctx, newSCSIController)
+		}
+		return "", "", err
+	}
+
+	deviceName, diskUUID, err := vm.GetVMDiskInfo(ctx, disk)
+	if err != nil {
+		glog.Errorf("Error occurred while getting Disk Info, err: %v", err)
+		if newSCSIController != nil {
+			vm.DeleteController(ctx, newSCSIController)
+		}
+		vm.DetachDisk(ctx, vmDiskPath)
+		return "", "", err
+	}
+	return deviceName, diskUUID, nil
+}
+
+func (vm VirtualMachine) GetVMDiskInfo(ctx context.Context, disk *types.VirtualDisk) (string, string, error) {
+	vmDevices, err := vm.Device(ctx)
+	if err != nil {
+		glog.Errorf("Error occurred while getting VM devices, err: %v", err)
+		return "", "", err
+	}
+	devices := vmDevices.SelectByType(disk)
+	if len(devices) < 1 {
+		return "", "", ErrNoDevicesFound
+	}
+
+	// get new disk id
+	newDevice := devices[len(devices)-1]
+	deviceName := devices.Name(newDevice)
+
+	// get device uuid
+	diskUUID, err := GetVirtualDiskUUIDByDevice(newDevice)
+	if err != nil {
+		glog.Errorf("Error occurred while getting Disk UUID of the device, err: %v", err)
+		return "", "", err
+	}
+
+	return deviceName, diskUUID, nil
+}
+
+// DetachDisk detaches the disk specified by vmDiskPath
+func (vm VirtualMachine) DetachDisk(ctx context.Context, vmDiskPath string) error {
+	vmDevices, err := vm.Device(ctx)
+	if err != nil {
+		glog.Errorf("Error occurred while getting VM devices, err: %v", err)
+		return err
+	}
+	diskID, err := vm.GetVirtualDiskID(ctx, vmDiskPath)
+	if err != nil {
+		glog.Errorf("disk ID not found for %v ", vmDiskPath)
+		return err
+	}
+	// Gets virtual disk device
+	device := vmDevices.Find(diskID)
+	if device == nil {
+		glog.Errorf("device '%s' not found", diskID)
+		return fmt.Errorf("device '%s' not found", diskID)
+	}
+	// Detach disk from VM
+	err = vm.RemoveDevice(ctx, true, device)
+	if err != nil {
+		glog.Errorf("Error occurred while removing disk device, err: %v", err)
+		return err
+	}
+	return nil
+}
+
+// Create and Attach a SCSI controller to VM.
+func (vm VirtualMachine) CreateAndAttachSCSIController(ctx context.Context, diskControllerType string) (types.BaseVirtualDevice, error) {
+	// Get VM device list
+	vmDevices, err := vm.Device(ctx)
+	if err != nil {
+		glog.Errorf("Error occurred while getting VM devices, err: %v", err)
+		return nil, err
+	}
+	allSCSIControllers := getSCSIControllers(vmDevices)
+	if len(allSCSIControllers) >= SCSIControllerLimit {
+		// we reached the maximum number of controllers we can attach
+		glog.Errorf("SCSI Controller Limit of %d has been reached, cannot create another SCSI controller", SCSIControllerLimit)
+		return nil, fmt.Errorf("SCSI Controller Limit of %d has been reached, cannot create another SCSI controller", SCSIControllerLimit)
+	}
+	newSCSIController, err := vmDevices.CreateSCSIController(diskControllerType)
+	if err != nil {
+		glog.Errorf("error creating new SCSI controller: %v", err)
+		return nil, err
+	}
+	configNewSCSIController := newSCSIController.(types.BaseVirtualSCSIController).GetVirtualSCSIController()
+	hotAndRemove := true
+	configNewSCSIController.HotAddRemove = &hotAndRemove
+	configNewSCSIController.SharedBus = types.VirtualSCSISharing(types.VirtualSCSISharingNoSharing)
+
+	// add the scsi controller to virtual machine
+	err = vm.AddDevice(context.TODO(), newSCSIController)
+	if err != nil {
+		glog.V(LOG_LEVEL).Infof("cannot add SCSI controller to vm. err: %v", err)
+		// attempt clean up of scsi controller
+		vm.DeleteController(ctx, newSCSIController)
+		return nil, err
+	}
+	return newSCSIController, nil
+}
+
+// Get VM's Resource Pool
+func (vm VirtualMachine) GetResourcePool(ctx context.Context) (*object.ResourcePool, error) {
+	currentVMHost, err := vm.HostSystem(ctx)
+	if err != nil {
+		glog.Errorf("Failed to get hostsystem for VM, err: %v", err)
+		return nil, err
+	}
+	// Get the resource pool for the current node.
+	// We create the dummy VM in the same resource pool as current node.
+	resourcePool, err := currentVMHost.ResourcePool(ctx)
+	if err != nil {
+		glog.Errorf("Failed to get resource pool of the VM, err: %v", err)
+		return nil, err
+	}
+	return resourcePool, nil
+}
+
+// Removes latest added SCSI controller from VM.
+func (vm VirtualMachine) DeleteController(ctx context.Context, controllerDevice types.BaseVirtualDevice) error {
+	if controllerDevice == nil {
+		glog.Errorf("Nil value is set for controllerDevice")
+		return fmt.Errorf("Nil value is set for controllerDevice")
+	}
+	if vm.VirtualMachine == nil {
+		glog.Errorf("Nil value is set for vm.VirtualMachine")
+		return fmt.Errorf("Nil value is set for vm.VirtualMachine")
+	}
+	// Get VM device list
+	vmDevices, err := vm.Device(ctx)
+	if err != nil {
+		glog.Errorf("Error occurred while getting VM devices, err: %v", err)
+		return err
+	}
+	controllerDeviceList := vmDevices.SelectByType(controllerDevice)
+	if len(controllerDeviceList) < 1 {
+		return ErrNoDevicesFound
+	}
+	device := controllerDeviceList[len(controllerDeviceList)-1]
+	err = vm.RemoveDevice(ctx, true, device)
+	if err != nil {
+		glog.Errorf("Error occurred while removing device, err: %v", err)
+		return err
+	}
+	return nil
+}
+
+// Get the list of Accessible Datastores for the given Virtual Machine
+func (vm VirtualMachine) GetAllAccessibleDatastores(ctx context.Context) ([]string, error) {
+	host, err := vm.HostSystem(ctx)
+	if err != nil {
+		return nil, err
+	}
+	var hostSystemMo mo.HostSystem
+	s := object.NewSearchIndex(vm.Client())
+	err = s.Properties(ctx, host.Reference(), []string{DatastoreProperty}, &hostSystemMo)
+	if err != nil {
+		return nil, err
+	}
+	var dsRefValues []string
+	for _, dsRef := range hostSystemMo.Datastore {
+		dsRefValues = append(dsRefValues, dsRef.Value)
+	}
+	return dsRefValues, nil
+}

--- a/pkg/cloudprovider/providers/vsphere/vclib/volumeoptions.go
+++ b/pkg/cloudprovider/providers/vsphere/vclib/volumeoptions.go
@@ -1,0 +1,78 @@
+package vclib
+
+import (
+	"github.com/golang/glog"
+	"strings"
+)
+
+// VolumeOptions specifies capacity, tags, name and diskFormat for a volume.
+type VolumeOptions struct {
+	CapacityKB             int
+	Tags                   map[string]string
+	Name                   string
+	DiskFormat             string
+	Datastore              string
+	VSANStorageProfileData string
+	StoragePolicyName      string
+	StoragePolicyID        string
+	SSCIControllerType     string
+}
+
+var (
+	diskFormatValidType = map[string]string{
+		ThinDiskType:                              ThinDiskType,
+		strings.ToLower(EagerZeroedThickDiskType): EagerZeroedThickDiskType,
+		strings.ToLower(ZeroedThickDiskType):      PreallocatedDiskType,
+	}
+	SCSIControllerValidType = []string{LSILogicSASControllerType, PVSCSIControllerType}
+)
+
+// Generates Valid Options for Diskformat
+func DiskformatValidOptions() string {
+	validopts := ""
+	for diskformat := range diskFormatValidType {
+		validopts += diskformat + ", "
+	}
+	validopts = strings.TrimSuffix(validopts, ", ")
+	return validopts
+}
+
+// check given diskFormat is valid diskFormat
+func CheckDiskFormatSupported(diskFormat string) bool {
+	if diskFormatValidType[diskFormat] == "" {
+		glog.Error("Not a valid Disk Format, Valid options are %s.", DiskformatValidOptions)
+		return false
+	}
+	return true
+}
+
+// Generates Valid Options for SCSIControllerType
+func SCSIControllerTypeValidOptions() string {
+	validopts := ""
+	for _, controllerType := range SCSIControllerValidType {
+		validopts += (controllerType + ", ")
+	}
+	validopts = strings.TrimSuffix(validopts, ", ")
+	return validopts
+}
+
+// check if the given controller type is valid
+func CheckControllerSupported(ctrlType string) bool {
+	for _, c := range SCSIControllerValidType {
+		if ctrlType == c {
+			return true
+		}
+	}
+	glog.Error("Not a valid SCSI Controller Type, Valid options are %s.", SCSIControllerTypeValidOptions)
+	return false
+}
+
+// check volumeOptions.SSCIControllerType is valid controller type
+func (volumeOptions VolumeOptions) VerifyVolumeOptions() (valid bool) {
+	valid = CheckControllerSupported(volumeOptions.SSCIControllerType)
+	if !valid {
+		return
+	}
+	valid = CheckDiskFormatSupported(volumeOptions.DiskFormat)
+	return
+}


### PR DESCRIPTION
Issue: https://github.com/vmware/kubernetes/issues/134

At present https://github.com/kubernetes/kubernetes/blob/master/pkg/cloudprovider/providers/vsphere/vsphere.go is huge. It has 1800+ lines of code dumped into single file, and as we add new feature, file size is increasing. It's already difficult to manage and debug code. Plan is to make the code modular and unit testable.

This PR is segregating vSphere cloud provider code into distinguishable vSphere Objects, such as VSphereConnection, DataCenter, DataStore and VirtualMachine. 

These objects inherits and extends govmomi objects, which allows govmomi functions readily available in cloud provider code, without requiring to re-create objects.

Code change for Integration with cloud provider will be sent in separate PR, after all functions are thoroughly unit tested.

@BaluDontu  @SandeepPissay @luomiao @tusharnt @pdhamdhere 

 