### PR TITLE
Adding vsphere Storage API Latency and Error Metrics support

### DIFF
--- a/pkg/cloudprovider/providers/vsphere/BUILD
+++ b/pkg/cloudprovider/providers/vsphere/BUILD
@@ -12,6 +12,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "vsphere.go",
+        "vsphere_metrics.go",
         "vsphere_util.go",
     ],
     tags = ["automanaged"],
@@ -33,6 +34,7 @@ go_library(
         "//vendor/github.com/vmware/govmomi/vim25/soap:go_default_library",
         "//vendor/github.com/vmware/govmomi/vim25/types:go_default_library",
         "//vendor/golang.org/x/net/context:go_default_library",
+        "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
         "//vendor/gopkg.in/gcfg.v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/runtime:go_default_library",

--- a/pkg/cloudprovider/providers/vsphere/vsphere.go
+++ b/pkg/cloudprovider/providers/vsphere/vsphere.go
@@ -886,12 +886,8 @@ func (vs *VSphere) AttachDisk(vmDiskPath string, storagePolicyID string, nodeNam
 	}
 	requestTime := time.Now()
 	diskID, diskUUID, err = attachDiskInternal(vmDiskPath, storagePolicyID, nodeName)
-	if err != nil {
-		recordvSphereMetric(request_attachvolume, time.Time{}, err)
-		return diskID, diskUUID, err
-	}
-	recordvSphereMetric(request_attachvolume, requestTime, nil)
-	return diskID, diskUUID, nil
+	recordvSphereMetric(request_attachvolume, requestTime, err)
+	return diskID, diskUUID, err
 }
 
 func getVMDiskInfo(ctx context.Context, vm *object.VirtualMachine, disk *types.VirtualDisk) (string, string, error) {
@@ -1039,10 +1035,6 @@ func (vs *VSphere) DiskIsAttached(volPath string, nodeName k8stypes.NodeName) (b
 	}
 	requestTime := time.Now()
 	isAttached, err := diskIsAttachedInternal(volPath, nodeName)
-	if err != nil {
-		recordvSphereMetric(request_diskIsAttached, time.Time{}, err)
-		return isAttached, err
-	}
 	recordvSphereMetric(request_diskIsAttached, requestTime, err)
 	return isAttached, err
 }
@@ -1109,10 +1101,6 @@ func (vs *VSphere) DisksAreAttached(volPaths []string, nodeName k8stypes.NodeNam
 	}
 	requestTime := time.Now()
 	attached, err := disksAreAttachedInternal(volPaths, nodeName)
-	if err != nil {
-		recordvSphereMetric(request_disksAreAttached, time.Time{}, err)
-		return attached, err
-	}
 	recordvSphereMetric(request_disksAreAttached, requestTime, err)
 	return attached, err
 }
@@ -1286,12 +1274,8 @@ func (vs *VSphere) DetachDisk(volPath string, nodeName k8stypes.NodeName) error 
 	}
 	requestTime := time.Now()
 	err := detachDiskInternal(volPath, nodeName)
-	if err != nil {
-		recordvSphereMetric(request_detachvolume, time.Time{}, err)
-		return err
-	}
 	recordvSphereMetric(request_detachvolume, requestTime, nil)
-	return nil
+	return err
 
 }
 
@@ -1539,12 +1523,8 @@ func (vs *VSphere) DeleteVolume(vmDiskPath string) error {
 	}
 	requestTime := time.Now()
 	err := deleteVolumeInternal(vmDiskPath)
-	if err != nil {
-		recordvSphereMetric(request_deletevolume, time.Time{}, err)
-		return err
-	}
 	recordvSphereMetric(request_deletevolume, requestTime, err)
-	return nil
+	return err
 }
 
 // NodeExists checks if the node with given nodeName exist.

--- a/pkg/cloudprovider/providers/vsphere/vsphere_metrics.go
+++ b/pkg/cloudprovider/providers/vsphere/vsphere_metrics.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vsphere
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"time"
+)
+
+const (
+	request_createvolume                      = "CreateVolume"
+	request_createvolume_with_policy          = "CreateVolumeWithPolicy"
+	request_createvolume_with_raw_vsan_policy = "CreateVolumeWithRawVSANPolicy"
+	request_deletevolume                      = "DeleteVolume"
+	request_attachvolume                      = "AttachVolume"
+	request_detachvolume                      = "DetachVolume"
+	request_diskIsAttached                    = "DiskIsAttached"
+	request_disksAreAttached                  = "DisksAreAttached"
+)
+
+var vsphereApiMetric = prometheus.NewHistogramVec(
+	prometheus.HistogramOpts{
+		Name: "cloudprovider_vsphere_api_request_duration_seconds",
+		Help: "Latency of vsphere api call",
+	},
+	[]string{"request"},
+)
+
+var vsphereApiErrorMetric = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "cloudprovider_vsphere_api_request_errors",
+		Help: "vsphere Api errors",
+	},
+	[]string{"request"},
+)
+
+func registerMetrics() {
+	prometheus.MustRegister(vsphereApiMetric)
+	prometheus.MustRegister(vsphereApiErrorMetric)
+}
+
+func recordvSphereMetric(actionName string, requestTime time.Time, err error) {
+	var timeTaken float64
+	if !requestTime.IsZero() {
+		timeTaken = time.Since(requestTime).Seconds()
+	} else {
+		timeTaken = 0
+	}
+	if err != nil {
+		vsphereApiErrorMetric.With(prometheus.Labels{"request": actionName}).Inc()
+	} else {
+		vsphereApiMetric.With(prometheus.Labels{"request": actionName}).Observe(timeTaken)
+	}
+}
+
+func recordCreateVolumeMetric(volumeOptions *VolumeOptions, requestTime time.Time, err error) {
+	var actionName string
+	if volumeOptions.StoragePolicyName != "" {
+		actionName = request_createvolume_with_policy
+	} else if volumeOptions.VSANStorageProfileData != "" {
+		actionName = request_createvolume_with_raw_vsan_policy
+	} else {
+		actionName = request_createvolume
+	}
+	var timeTaken float64
+	if !requestTime.IsZero() {
+		timeTaken = time.Since(requestTime).Seconds()
+	} else {
+		timeTaken = 0
+	}
+	if err != nil {
+		vsphereApiErrorMetric.With(prometheus.Labels{"request": actionName}).Inc()
+	} else {
+		vsphereApiMetric.With(prometheus.Labels{"request": actionName}).Observe(timeTaken)
+	}
+}

--- a/pkg/cloudprovider/providers/vsphere/vsphere_metrics.go
+++ b/pkg/cloudprovider/providers/vsphere/vsphere_metrics.go
@@ -54,16 +54,10 @@ func registerMetrics() {
 }
 
 func recordvSphereMetric(actionName string, requestTime time.Time, err error) {
-	var timeTaken float64
-	if !requestTime.IsZero() {
-		timeTaken = time.Since(requestTime).Seconds()
-	} else {
-		timeTaken = 0
-	}
 	if err != nil {
 		vsphereApiErrorMetric.With(prometheus.Labels{"request": actionName}).Inc()
 	} else {
-		vsphereApiMetric.With(prometheus.Labels{"request": actionName}).Observe(timeTaken)
+		vsphereApiMetric.With(prometheus.Labels{"request": actionName}).Observe(calculateTimeTaken(requestTime))
 	}
 }
 
@@ -76,15 +70,19 @@ func recordCreateVolumeMetric(volumeOptions *VolumeOptions, requestTime time.Tim
 	} else {
 		actionName = request_createvolume
 	}
-	var timeTaken float64
-	if !requestTime.IsZero() {
-		timeTaken = time.Since(requestTime).Seconds()
-	} else {
-		timeTaken = 0
-	}
 	if err != nil {
 		vsphereApiErrorMetric.With(prometheus.Labels{"request": actionName}).Inc()
 	} else {
-		vsphereApiMetric.With(prometheus.Labels{"request": actionName}).Observe(timeTaken)
+
+		vsphereApiMetric.With(prometheus.Labels{"request": actionName}).Observe(calculateTimeTaken(requestTime))
 	}
+}
+
+func calculateTimeTaken(requestBeginTime time.Time) (timeTaken float64) {
+	if !requestBeginTime.IsZero() {
+		timeTaken = time.Since(requestBeginTime).Seconds()
+	} else {
+		timeTaken = 0
+	}
+	return timeTaken
 }


### PR DESCRIPTION
Issue: https://github.com/vmware/kubernetes/issues/146

Details:
https://confluence.eng.vmware.com/pages/viewpage.action?spaceKey=CNAS&title=CloudProvider+Metrices+for+Storage

**Performed following operations on the Cluster**
1. Created volume with out any policy or vsan raw policy parameters and Created Pod to use this volume.
2. Created volume with VSAN Storage Policy and Created pod to use this volume.
3. Created volume with vsan raw policy parameters and Created pod to use this volume.
4. Tried to create a PV using incorrect profile name in the storage class, deleted failed pending PVC.

**Verified metrics are being reported correctly using controller's URL from the master node.**

```
root@master [ ~ ]# curl -s http://localhost:10252/metrics | grep "cloudprovider_vsphere_api_request_duration_seconds_count"
cloudprovider_vsphere_api_request_duration_seconds_count{request="AttachVolume"} 3
cloudprovider_vsphere_api_request_duration_seconds_count{request="CreateVolume"} 1
cloudprovider_vsphere_api_request_duration_seconds_count{request="CreateVolumeWithPolicy"} 1
cloudprovider_vsphere_api_request_duration_seconds_count{request="CreateVolumeWithRawVSANPolicy"} 1
cloudprovider_vsphere_api_request_duration_seconds_count{request="DetachVolume"} 2
cloudprovider_vsphere_api_request_duration_seconds_count{request="DisksAreAttached"} 70
```

```
root@master [ ~ ]# curl -s http://localhost:10252/metrics | grep "cloudprovider_vsphere_api_request_duration_seconds_sum"
cloudprovider_vsphere_api_request_duration_seconds_sum{request="AttachVolume"} 4.31064569
cloudprovider_vsphere_api_request_duration_seconds_sum{request="CreateVolume"} 1.359351884
cloudprovider_vsphere_api_request_duration_seconds_sum{request="CreateVolumeWithPolicy"} 15.277168076
cloudprovider_vsphere_api_request_duration_seconds_sum{request="CreateVolumeWithRawVSANPolicy"} 22.957720698
cloudprovider_vsphere_api_request_duration_seconds_sum{request="DetachVolume"} 3.8536143010000004
cloudprovider_vsphere_api_request_duration_seconds_sum{request="DisksAreAttached"} 120.55611070500002
```

```
root@master [ ~ ]# curl -s http://localhost:10252/metrics | grep "vsphere_api_request_errors"
# HELP cloudprovider_vsphere_api_request_errors vsphere Api errors
# TYPE cloudprovider_vsphere_api_request_errors counter
cloudprovider_vsphere_api_request_errors{request="CreateVolumeWithPolicy"} 4
```

```
root@master [ ~ ]# curl -s http://localhost:10252/metrics | grep "cloudprovider_vsphere_api_request_duration_seconds_bucket"
cloudprovider_vsphere_api_request_duration_seconds_bucket{request="AttachVolume",le="0.005"} 0
cloudprovider_vsphere_api_request_duration_seconds_bucket{request="AttachVolume",le="0.01"} 0
cloudprovider_vsphere_api_request_duration_seconds_bucket{request="AttachVolume",le="0.025"} 0
cloudprovider_vsphere_api_request_duration_seconds_bucket{request="AttachVolume",le="0.05"} 0
cloudprovider_vsphere_api_request_duration_seconds_bucket{request="AttachVolume",le="0.1"} 0
cloudprovider_vsphere_api_request_duration_seconds_bucket{request="AttachVolume",le="0.25"} 0
cloudprovider_vsphere_api_request_duration_seconds_bucket{request="AttachVolume",le="0.5"} 0
cloudprovider_vsphere_api_request_duration_seconds_bucket{request="AttachVolume",le="1"} 0
cloudprovider_vsphere_api_request_duration_seconds_bucket{request="AttachVolume",le="2.5"} 3
cloudprovider_vsphere_api_request_duration_seconds_bucket{request="AttachVolume",le="5"} 3
cloudprovider_vsphere_api_request_duration_seconds_bucket{request="AttachVolume",le="10"} 3
cloudprovider_vsphere_api_request_duration_seconds_bucket{request="AttachVolume",le="+Inf"} 3
cloudprovider_vsphere_api_request_duration_seconds_bucket{request="CreateVolume",le="0.005"} 0
cloudprovider_vsphere_api_request_duration_seconds_bucket{request="CreateVolume",le="0.01"} 0
cloudprovider_vsphere_api_request_duration_seconds_bucket{request="CreateVolume",le="0.025"} 0
cloudprovider_vsphere_api_request_duration_seconds_bucket{request="CreateVolume",le="0.05"} 0
cloudprovider_vsphere_api_request_duration_seconds_bucket{request="CreateVolume",le="0.1"} 0
cloudprovider_vsphere_api_request_duration_seconds_bucket{request="CreateVolume",le="0.25"} 0
cloudprovider_vsphere_api_request_duration_seconds_bucket{request="CreateVolume",le="0.5"} 0
cloudprovider_vsphere_api_request_duration_seconds_bucket{request="CreateVolume",le="1"} 0
cloudprovider_vsphere_api_request_duration_seconds_bucket{request="CreateVolume",le="2.5"} 1
cloudprovider_vsphere_api_request_duration_seconds_bucket{request="CreateVolume",le="5"} 1
cloudprovider_vsphere_api_request_duration_seconds_bucket{request="CreateVolume",le="10"} 1
cloudprovider_vsphere_api_request_duration_seconds_bucket{request="CreateVolume",le="+Inf"} 1
cloudprovider_vsphere_api_request_duration_seconds_bucket{request="CreateVolumeWithPolicy",le="0.005"} 0
cloudprovider_vsphere_api_request_duration_seconds_bucket{request="CreateVolumeWithPolicy",le="0.01"} 0
cloudprovider_vsphere_api_request_duration_seconds_bucket{request="CreateVolumeWithPolicy",le="0.025"} 0
cloudprovider_vsphere_api_request_duration_seconds_bucket{request="CreateVolumeWithPolicy",le="0.05"} 0
cloudprovider_vsphere_api_request_duration_seconds_bucket{request="CreateVolumeWithPolicy",le="0.1"} 0
cloudprovider_vsphere_api_request_duration_seconds_bucket{request="CreateVolumeWithPolicy",le="0.25"} 0
cloudprovider_vsphere_api_request_duration_seconds_bucket{request="CreateVolumeWithPolicy",le="0.5"} 0
cloudprovider_vsphere_api_request_duration_seconds_bucket{request="CreateVolumeWithPolicy",le="1"} 0
cloudprovider_vsphere_api_request_duration_seconds_bucket{request="CreateVolumeWithPolicy",le="2.5"} 0
cloudprovider_vsphere_api_request_duration_seconds_bucket{request="CreateVolumeWithPolicy",le="5"} 0
cloudprovider_vsphere_api_request_duration_seconds_bucket{request="CreateVolumeWithPolicy",le="10"} 0
cloudprovider_vsphere_api_request_duration_seconds_bucket{request="CreateVolumeWithPolicy",le="+Inf"} 1
cloudprovider_vsphere_api_request_duration_seconds_bucket{request="CreateVolumeWithRawVSANPolicy",le="0.005"} 0
cloudprovider_vsphere_api_request_duration_seconds_bucket{request="CreateVolumeWithRawVSANPolicy",le="0.01"} 0
cloudprovider_vsphere_api_request_duration_seconds_bucket{request="CreateVolumeWithRawVSANPolicy",le="0.025"} 0
cloudprovider_vsphere_api_request_duration_seconds_bucket{request="CreateVolumeWithRawVSANPolicy",le="0.05"} 0
cloudprovider_vsphere_api_request_duration_seconds_bucket{request="CreateVolumeWithRawVSANPolicy",le="0.1"} 0
cloudprovider_vsphere_api_request_duration_seconds_bucket{request="CreateVolumeWithRawVSANPolicy",le="0.25"} 0
cloudprovider_vsphere_api_request_duration_seconds_bucket{request="CreateVolumeWithRawVSANPolicy",le="0.5"} 0
cloudprovider_vsphere_api_request_duration_seconds_bucket{request="CreateVolumeWithRawVSANPolicy",le="1"} 0
cloudprovider_vsphere_api_request_duration_seconds_bucket{request="CreateVolumeWithRawVSANPolicy",le="2.5"} 0
cloudprovider_vsphere_api_request_duration_seconds_bucket{request="CreateVolumeWithRawVSANPolicy",le="5"} 0
cloudprovider_vsphere_api_request_duration_seconds_bucket{request="CreateVolumeWithRawVSANPolicy",le="10"} 0
cloudprovider_vsphere_api_request_duration_seconds_bucket{request="CreateVolumeWithRawVSANPolicy",le="+Inf"} 1
cloudprovider_vsphere_api_request_duration_seconds_bucket{request="DetachVolume",le="0.005"} 0
cloudprovider_vsphere_api_request_duration_seconds_bucket{request="DetachVolume",le="0.01"} 0
cloudprovider_vsphere_api_request_duration_seconds_bucket{request="DetachVolume",le="0.025"} 0
cloudprovider_vsphere_api_request_duration_seconds_bucket{request="DetachVolume",le="0.05"} 0
cloudprovider_vsphere_api_request_duration_seconds_bucket{request="DetachVolume",le="0.1"} 0
cloudprovider_vsphere_api_request_duration_seconds_bucket{request="DetachVolume",le="0.25"} 0
cloudprovider_vsphere_api_request_duration_seconds_bucket{request="DetachVolume",le="0.5"} 0
cloudprovider_vsphere_api_request_duration_seconds_bucket{request="DetachVolume",le="1"} 0
cloudprovider_vsphere_api_request_duration_seconds_bucket{request="DetachVolume",le="2.5"} 1
cloudprovider_vsphere_api_request_duration_seconds_bucket{request="DetachVolume",le="5"} 2
cloudprovider_vsphere_api_request_duration_seconds_bucket{request="DetachVolume",le="10"} 2
cloudprovider_vsphere_api_request_duration_seconds_bucket{request="DetachVolume",le="+Inf"} 2
cloudprovider_vsphere_api_request_duration_seconds_bucket{request="DisksAreAttached",le="0.005"} 0
cloudprovider_vsphere_api_request_duration_seconds_bucket{request="DisksAreAttached",le="0.01"} 0
cloudprovider_vsphere_api_request_duration_seconds_bucket{request="DisksAreAttached",le="0.025"} 0
cloudprovider_vsphere_api_request_duration_seconds_bucket{request="DisksAreAttached",le="0.05"} 0
cloudprovider_vsphere_api_request_duration_seconds_bucket{request="DisksAreAttached",le="0.1"} 0
cloudprovider_vsphere_api_request_duration_seconds_bucket{request="DisksAreAttached",le="0.25"} 5
cloudprovider_vsphere_api_request_duration_seconds_bucket{request="DisksAreAttached",le="0.5"} 39
cloudprovider_vsphere_api_request_duration_seconds_bucket{request="DisksAreAttached",le="1"} 66
cloudprovider_vsphere_api_request_duration_seconds_bucket{request="DisksAreAttached",le="2.5"} 66
cloudprovider_vsphere_api_request_duration_seconds_bucket{request="DisksAreAttached",le="5"} 68
cloudprovider_vsphere_api_request_duration_seconds_bucket{request="DisksAreAttached",le="10"} 68
cloudprovider_vsphere_api_request_duration_seconds_bucket{request="DisksAreAttached",le="+Inf"} 68
root@master [ ~ ]#
```

@BaluDontu @SandeepPissay @luomiao @tusharnt @pdhamdhere