### PR TITLE
Adding guestbook, minio and mongodb-shards yamls for K8S documentation

### DIFF
--- a/kube-examples/guestbook/guestbook-pvc/guestbook-all-in-one.yaml
+++ b/kube-examples/guestbook/guestbook-pvc/guestbook-all-in-one.yaml
@@ -1,0 +1,193 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis-master
+  labels:
+    app: redis
+    tier: backend
+    role: master
+spec:
+  ports:
+    # the port that this service should serve on
+  - port: 6379
+    targetPort: 6379
+  selector:
+    app: redis
+    tier: backend
+    role: master
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: redis-master
+  # these labels can be applied automatically
+  # from the labels in the pod template if not set
+  # labels:
+  #   app: redis
+  #   role: master
+  #   tier: backend
+spec:
+  # this replicas value is default
+  # modify it according to your case
+  replicas: 1
+  # selector can be applied automatically
+  # from the labels in the pod template if not set
+  # selector:
+  #   matchLabels:
+  #     app: guestbook
+  #     role: master
+  #     tier: backend
+  template:
+    metadata:
+      labels:
+        app: redis
+        role: master
+        tier: backend
+    spec:
+      containers:
+      - name: master
+        image: gcr.io/google_containers/redis:e2e  # or just image: redis
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        ports:
+        - containerPort: 6379
+        volumeMounts:
+        - name: redis-master-data
+          mountPath: /data
+      volumes: 
+      - name: redis-master-data
+        persistentVolumeClaim:
+          claimName: redis-master-claim
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis-slave
+  labels:
+    app: redis
+    tier: backend
+    role: slave
+spec:
+  ports:
+    # the port that this service should serve on
+  - port: 6379
+  selector:
+    app: redis
+    tier: backend
+    role: slave
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: redis-slave
+  # these labels can be applied automatically
+  # from the labels in the pod template if not set
+  # labels:
+  #   app: redis
+  #   role: slave
+  #   tier: backend
+spec:
+  # this replicas value is default
+  # modify it according to your case
+  replicas: 1
+  # selector can be applied automatically
+  # from the labels in the pod template if not set
+  # selector:
+  #   matchLabels:
+  #     app: guestbook
+  #     role: slave
+  #     tier: backend
+  template:
+    metadata:
+      labels:
+        app: redis
+        role: slave
+        tier: backend
+    spec:
+      containers:
+      - name: slave
+        image: gcr.io/google_samples/gb-redisslave:v1
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        env:
+        - name: GET_HOSTS_FROM
+          value: dns
+          # If your cluster config does not include a dns service, then to
+          # instead access an environment variable to find the master
+          # service's host, comment out the 'value: dns' line above, and
+          # uncomment the line below.
+          # value: env
+        ports:
+        - containerPort: 6379
+        volumeMounts:
+        - name: redis-slave-data
+          mountPath: /data
+      volumes: 
+      - name: redis-slave-data
+        persistentVolumeClaim:
+          claimName: redis-slave-claim
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend
+  labels:
+    app: guestbook
+    tier: frontend
+spec:
+  # if your cluster supports it, uncomment the following to automatically create
+  # an external load-balanced IP for the frontend service.
+  type: NodePort
+  ports:
+    # the port that this service should serve on
+  - port: 80
+  selector:
+    app: guestbook
+    tier: frontend
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: frontend
+  # these labels can be applied automatically
+  # from the labels in the pod template if not set
+  # labels:
+  #   app: guestbook
+  #   tier: frontend
+spec:
+  # this replicas value is default
+  # modify it according to your case
+  replicas: 4
+  # selector can be applied automatically
+  # from the labels in the pod template if not set
+  # selector:
+  #   matchLabels:
+  #     app: guestbook
+  #     tier: frontend
+  template:
+    metadata:
+      labels:
+        app: guestbook
+        tier: frontend
+    spec:
+      containers:
+      - name: php-redis
+        image: gcr.io/google-samples/gb-frontend:v4
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        env:
+        - name: GET_HOSTS_FROM
+          value: dns
+          # If your cluster config does not include a dns service, then to
+          # instead access environment variables to find service host
+          # info, comment out the 'value: dns' line above, and uncomment the
+          # line below.
+          # value: env
+        ports:
+        - containerPort: 80

--- a/kube-examples/guestbook/guestbook-pvc/redis-master-claim.yaml
+++ b/kube-examples/guestbook/guestbook-pvc/redis-master-claim.yaml
@@ -1,0 +1,10 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: redis-master-claim
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi

--- a/kube-examples/guestbook/guestbook-pvc/redis-master-pv.yaml
+++ b/kube-examples/guestbook/guestbook-pvc/redis-master-pv.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: redis-master-pv
+spec:
+  capacity:
+    storage: 2Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  vsphereVolume:
+    volumePath: "[datastore1] kubevols/redis-master"
+    fsType: ext4 

--- a/kube-examples/guestbook/guestbook-pvc/redis-slave-claim.yaml
+++ b/kube-examples/guestbook/guestbook-pvc/redis-slave-claim.yaml
@@ -1,0 +1,10 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: redis-slave-claim
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi

--- a/kube-examples/guestbook/guestbook-pvc/redis-slave-pv.yaml
+++ b/kube-examples/guestbook/guestbook-pvc/redis-slave-pv.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: redis-slave-pv
+spec:
+  capacity:
+    storage: 2Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  vsphereVolume:
+    volumePath: "[datastore1] kubevols/redis-slave"
+    fsType: ext4 

--- a/kube-examples/guestbook/guestbook-storageclass/guestbook-all-in-one.yaml
+++ b/kube-examples/guestbook/guestbook-storageclass/guestbook-all-in-one.yaml
@@ -1,0 +1,193 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis-master
+  labels:
+    app: redis
+    tier: backend
+    role: master
+spec:
+  ports:
+    # the port that this service should serve on
+  - port: 6379
+    targetPort: 6379
+  selector:
+    app: redis
+    tier: backend
+    role: master
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: redis-master
+  # these labels can be applied automatically
+  # from the labels in the pod template if not set
+  # labels:
+  #   app: redis
+  #   role: master
+  #   tier: backend
+spec:
+  # this replicas value is default
+  # modify it according to your case
+  replicas: 1
+  # selector can be applied automatically
+  # from the labels in the pod template if not set
+  # selector:
+  #   matchLabels:
+  #     app: guestbook
+  #     role: master
+  #     tier: backend
+  template:
+    metadata:
+      labels:
+        app: redis
+        role: master
+        tier: backend
+    spec:
+      containers:
+      - name: master
+        image: gcr.io/google_containers/redis:e2e  # or just image: redis
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        ports:
+        - containerPort: 6379
+        volumeMounts:
+        - name: redis-master-data
+          mountPath: /data
+      volumes: 
+      - name: redis-master-data
+        persistentVolumeClaim:
+          claimName: redis-master-claim
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis-slave
+  labels:
+    app: redis
+    tier: backend
+    role: slave
+spec:
+  ports:
+    # the port that this service should serve on
+  - port: 6379
+  selector:
+    app: redis
+    tier: backend
+    role: slave
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: redis-slave
+  # these labels can be applied automatically
+  # from the labels in the pod template if not set
+  # labels:
+  #   app: redis
+  #   role: slave
+  #   tier: backend
+spec:
+  # this replicas value is default
+  # modify it according to your case
+  replicas: 1
+  # selector can be applied automatically
+  # from the labels in the pod template if not set
+  # selector:
+  #   matchLabels:
+  #     app: guestbook
+  #     role: slave
+  #     tier: backend
+  template:
+    metadata:
+      labels:
+        app: redis
+        role: slave
+        tier: backend
+    spec:
+      containers:
+      - name: slave
+        image: gcr.io/google_samples/gb-redisslave:v1
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        env:
+        - name: GET_HOSTS_FROM
+          value: dns
+          # If your cluster config does not include a dns service, then to
+          # instead access an environment variable to find the master
+          # service's host, comment out the 'value: dns' line above, and
+          # uncomment the line below.
+          # value: env
+        ports:
+        - containerPort: 6379
+        volumeMounts:
+        - name: redis-slave-data
+          mountPath: /data
+      volumes: 
+      - name: redis-slave-data
+        persistentVolumeClaim:
+          claimName: redis-slave-claim
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend
+  labels:
+    app: guestbook
+    tier: frontend
+spec:
+  # if your cluster supports it, uncomment the following to automatically create
+  # an external load-balanced IP for the frontend service.
+  type: NodePort
+  ports:
+    # the port that this service should serve on
+  - port: 80
+  selector:
+    app: guestbook
+    tier: frontend
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: frontend
+  # these labels can be applied automatically
+  # from the labels in the pod template if not set
+  # labels:
+  #   app: guestbook
+  #   tier: frontend
+spec:
+  # this replicas value is default
+  # modify it according to your case
+  replicas: 4
+  # selector can be applied automatically
+  # from the labels in the pod template if not set
+  # selector:
+  #   matchLabels:
+  #     app: guestbook
+  #     tier: frontend
+  template:
+    metadata:
+      labels:
+        app: guestbook
+        tier: frontend
+    spec:
+      containers:
+      - name: php-redis
+        image: gcr.io/google-samples/gb-frontend:v4
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        env:
+        - name: GET_HOSTS_FROM
+          value: dns
+          # If your cluster config does not include a dns service, then to
+          # instead access environment variables to find service host
+          # info, comment out the 'value: dns' line above, and uncomment the
+          # line below.
+          # value: env
+        ports:
+        - containerPort: 80

--- a/kube-examples/guestbook/guestbook-storageclass/redis-master-claim.yaml
+++ b/kube-examples/guestbook/guestbook-storageclass/redis-master-claim.yaml
@@ -1,0 +1,12 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: redis-master-claim
+  annotations:
+    volume.beta.kubernetes.io/storage-class: thin-disk
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi

--- a/kube-examples/guestbook/guestbook-storageclass/redis-sc.yaml
+++ b/kube-examples/guestbook/guestbook-storageclass/redis-sc.yaml
@@ -1,0 +1,7 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: thin-disk
+provisioner: kubernetes.io/vsphere-volume
+parameters:
+    diskformat: thin

--- a/kube-examples/guestbook/guestbook-storageclass/redis-slave-claim.yaml
+++ b/kube-examples/guestbook/guestbook-storageclass/redis-slave-claim.yaml
@@ -1,0 +1,12 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: redis-slave-claim
+  annotations:
+    volume.beta.kubernetes.io/storage-class: thin-disk
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi

--- a/kube-examples/guestbook/guestbook-volumes/guestbook-all-in-one.yaml
+++ b/kube-examples/guestbook/guestbook-volumes/guestbook-all-in-one.yaml
@@ -1,0 +1,193 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis-master
+  labels:
+    app: redis
+    tier: backend
+    role: master
+spec:
+  ports:
+    # the port that this service should serve on
+  - port: 6379
+    targetPort: 6379
+  selector:
+    app: redis
+    tier: backend
+    role: master
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: redis-master
+  # these labels can be applied automatically
+  # from the labels in the pod template if not set
+  # labels:
+  #   app: redis
+  #   role: master
+  #   tier: backend
+spec:
+  # this replicas value is default
+  # modify it according to your case
+  replicas: 1
+  # selector can be applied automatically
+  # from the labels in the pod template if not set
+  # selector:
+  #   matchLabels:
+  #     app: guestbook
+  #     role: master
+  #     tier: backend
+  template:
+    metadata:
+      labels:
+        app: redis
+        role: master
+        tier: backend
+    spec:
+      containers:
+      - name: master
+        image: gcr.io/google_containers/redis:e2e  # or just image: redis
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        ports:
+        - containerPort: 6379
+        volumeMounts:
+        - name: redis-master-data
+          mountPath: /data
+      volumes: 
+      - name: redis-master-data
+        vsphereVolume:
+          volumePath: "[datastore1] kubevols/redis-master"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis-slave
+  labels:
+    app: redis
+    tier: backend
+    role: slave
+spec:
+  ports:
+    # the port that this service should serve on
+  - port: 6379
+  selector:
+    app: redis
+    tier: backend
+    role: slave
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: redis-slave
+  # these labels can be applied automatically
+  # from the labels in the pod template if not set
+  # labels:
+  #   app: redis
+  #   role: slave
+  #   tier: backend
+spec:
+  # this replicas value is default
+  # modify it according to your case
+  replicas: 1
+  # selector can be applied automatically
+  # from the labels in the pod template if not set
+  # selector:
+  #   matchLabels:
+  #     app: guestbook
+  #     role: slave
+  #     tier: backend
+  template:
+    metadata:
+      labels:
+        app: redis
+        role: slave
+        tier: backend
+    spec:
+      containers:
+      - name: slave
+        image: gcr.io/google_samples/gb-redisslave:v1
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        env:
+        - name: GET_HOSTS_FROM
+          value: dns
+          # If your cluster config does not include a dns service, then to
+          # instead access an environment variable to find the master
+          # service's host, comment out the 'value: dns' line above, and
+          # uncomment the line below.
+          # value: env
+        ports:
+        - containerPort: 6379
+        volumeMounts:
+        - name: redis-slave-data
+          mountPath: /data
+      volumes: 
+      - name: redis-slave-data
+        vsphereVolume:
+          volumePath: "[datastore1] kubevols/redis-slave"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend
+  labels:
+    app: guestbook
+    tier: frontend
+spec:
+  # if your cluster supports it, uncomment the following to automatically create
+  # an external load-balanced IP for the frontend service.
+  type: NodePort
+  ports:
+    # the port that this service should serve on
+  - port: 80
+  selector:
+    app: guestbook
+    tier: frontend
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: frontend
+  # these labels can be applied automatically
+  # from the labels in the pod template if not set
+  # labels:
+  #   app: guestbook
+  #   tier: frontend
+spec:
+  # this replicas value is default
+  # modify it according to your case
+  replicas: 4
+  # selector can be applied automatically
+  # from the labels in the pod template if not set
+  # selector:
+  #   matchLabels:
+  #     app: guestbook
+  #     tier: frontend
+  template:
+    metadata:
+      labels:
+        app: guestbook
+        tier: frontend
+    spec:
+      containers:
+      - name: php-redis
+        image: gcr.io/google-samples/gb-frontend:v4
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        env:
+        - name: GET_HOSTS_FROM
+          value: dns
+          # If your cluster config does not include a dns service, then to
+          # instead access environment variables to find service host
+          # info, comment out the 'value: dns' line above, and uncomment the
+          # line below.
+          # value: env
+        ports:
+        - containerPort: 80

--- a/kube-examples/minio/distributed/minio-distributed-statefulset.yaml
+++ b/kube-examples/minio/distributed/minio-distributed-statefulset.yaml
@@ -1,0 +1,64 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio
+  labels:
+    app: minio
+spec:
+  clusterIP: None
+  ports:
+    - port: 9000
+      name: minio
+  selector:
+    app: minio
+---
+apiVersion: apps/v1beta1
+kind: StatefulSet
+metadata:
+  name: minio
+spec:
+  serviceName: minio
+  replicas: 4
+  template:
+    metadata:
+      annotations:
+        pod.alpha.kubernetes.io/initialized: "true"
+      labels:
+        app: minio
+    spec:
+      containers:
+      - name: minio
+        env:
+        - name: MINIO_ACCESS_KEY
+          value: "minio"
+        - name: MINIO_SECRET_KEY
+          value: "minio123"
+        image: minio/minio:RELEASE.2017-05-05T01-14-51Z
+        args:
+        - server
+        - http://minio-0.minio.default.svc.cluster.local/data
+        - http://minio-1.minio.default.svc.cluster.local/data
+        - http://minio-2.minio.default.svc.cluster.local/data
+        - http://minio-3.minio.default.svc.cluster.local/data
+        ports:
+        - containerPort: 9000
+          hostPort: 9000
+        # These volume mounts are persistent. Each pod in the PetSet
+        # gets a volume mounted based on this field.
+        volumeMounts:
+        - name: data
+          mountPath: /data
+  # These are converted to volume claims by the controller
+  # and mounted at the paths mentioned above.
+  volumeClaimTemplates:
+  - metadata:
+      name: data
+      annotations:
+        volume.beta.kubernetes.io/storage-class: miniosc
+    spec:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: 5Gi
+

--- a/kube-examples/minio/distributed/minio_nodeport.yaml
+++ b/kube-examples/minio/distributed/minio_nodeport.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio-service
+spec:
+  type: NodePort
+  ports:
+    - port: 9000
+      nodePort: 30000
+  selector:
+    app: minio
+

--- a/kube-examples/minio/distributed/minio_sc.yaml
+++ b/kube-examples/minio/distributed/minio_sc.yaml
@@ -1,0 +1,7 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: miniosc
+provisioner: kubernetes.io/vsphere-volume
+parameters:
+    diskformat: thin

--- a/kube-examples/minio/standalone/minio-standalone-deployment.yaml
+++ b/kube-examples/minio/standalone/minio-standalone-deployment.yaml
@@ -1,0 +1,40 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  # This name uniquely identifies the Deployment
+  name: minio-deployment
+spec:
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        # Label is used as selector in the service.
+        app: minio
+    spec:
+      # Refer to the PVC created earlier
+      volumes:
+      - name: storage
+        persistentVolumeClaim:
+          # Name of the PVC created earlier
+          claimName: minio-pv-claim
+      containers:
+      - name: minio
+        # Pulls the default Minio image from Docker Hub
+        image: minio/minio:RELEASE.2017-05-05T01-14-51Z
+        args:
+        - server
+        - /storage
+        env:
+        # Minio access key and secret key
+        - name: MINIO_ACCESS_KEY
+          value: "minio"
+        - name: MINIO_SECRET_KEY
+          value: "minio123"
+        ports:
+        - containerPort: 9000
+          hostPort: 9000
+        # Mount the volume into the pod
+        volumeMounts:
+        - name: storage # must match the volume name, above
+          mountPath: "/storage"

--- a/kube-examples/minio/standalone/minio-standalone-pvc.yaml
+++ b/kube-examples/minio/standalone/minio-standalone-pvc.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  # This name uniquely identifies the PVC. Will be used in deployment below.
+  name: minio-pv-claim
+  annotations:
+    volume.beta.kubernetes.io/storage-class: miniosc
+  labels:
+    app: minio-storage-claim
+spec:
+  # Read more about access modes here: http://kubernetes.io/docs/user-guide/persistent-volumes/#access-modes
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    # This is the request for storage. Should be available in the cluster.
+    requests:
+      storage: 2Gi

--- a/kube-examples/minio/standalone/minio-standalone-service.yaml
+++ b/kube-examples/minio/standalone/minio-standalone-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio-service
+spec:
+  type: NodePort
+  ports:
+    - port: 9000
+      targetPort: 30000
+      protocol: TCP
+  selector:
+    app: minio

--- a/kube-examples/minio/standalone/minio_sc.yaml
+++ b/kube-examples/minio/standalone/minio_sc.yaml
@@ -1,0 +1,7 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: miniosc
+provisioner: kubernetes.io/vsphere-volume
+parameters:
+    diskformat: thin

--- a/kube-examples/mongodb-shards/create_node.sh
+++ b/kube-examples/mongodb-shards/create_node.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+kubectl create -f node01-deployment.yaml
+kubectl create -f node02-deployment.yaml
+kubectl create -f node03-deployment.yaml
+kubectl create -f node04-deployment.yaml

--- a/kube-examples/mongodb-shards/create_service.sh
+++ b/kube-examples/mongodb-shards/create_service.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+kubectl create -f node01-service.yaml
+kubectl create -f node02-service.yaml
+kubectl create -f node03-service.yaml
+kubectl create -f node04-service.yaml

--- a/kube-examples/mongodb-shards/create_storage.sh
+++ b/kube-examples/mongodb-shards/create_storage.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+kubectl create -f storageclass.yaml
+kubectl create -f storage-volumes-node01.yaml
+kubectl create -f storage-volumes-node02.yaml
+kubectl create -f storage-volumes-node03.yaml
+kubectl create -f storage-volumes-node04.yaml

--- a/kube-examples/mongodb-shards/node01-deployment.yaml
+++ b/kube-examples/mongodb-shards/node01-deployment.yaml
@@ -1,0 +1,118 @@
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: mongodb-shard-node01
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: mongodb-shard-node01
+        role: mongoshard
+        tier: backend
+    spec:
+      containers:
+        -
+          args:
+            - "--replSet"
+            - rs03
+            - "--port"
+            - "27019"
+            - "--shardsvr"
+            - "--journal"
+          image: "mongo:3.4"
+          name: arb03-node01
+          ports:
+            -
+              containerPort: 27019
+              name: arb03-node01
+          volumeMounts:
+            -
+              mountPath: /data/db
+              name: vsphere-storage-db-rsa03
+        -
+          args:
+            - "--replSet"
+            - rs04
+            - "--port"
+            - "27021"
+            - "--shardsvr"
+            - "--journal"
+          image: "mongo:3.4"
+          name: rss03-node01
+          ports:
+            -
+              containerPort: 27021
+              name: rss04-node01
+          volumeMounts:
+            -
+              mountPath: /data/db
+              name: vsphere-storage-db-rss04
+        -
+          args:
+            - "--replSet"
+            - rs01
+            - "--port"
+            - "27020"
+            - "--shardsvr"
+            - "--journal"
+          image: "mongo:3.4"
+          name: rsp01-node01
+          ports:
+            -
+              containerPort: 27020
+              name: rsp01-node01
+          volumeMounts:
+            -
+              mountPath: /data/db
+              name: vsphere-storage-db-rsp01
+        -
+          args:
+            - "--configsvr"
+            - "--replSet"
+            - configReplSet01
+            - "--port"
+            - "27018"
+          image: "mongo:3.4"
+          name: cfg01-node01
+          ports:
+            -
+              containerPort: 27018
+              name: cfg01-node01
+          volumeMounts:
+            -
+              mountPath: /data/db
+              name: vsphere-storage-mongoc01
+        -
+          args:
+            - "--configdb"
+            - "configReplSet01/mongodb-node01.default.svc.cluster.local:27018,mongodb-node02.default.svc.cluster.local:27018,mongodb-node03.default.svc.cluster.local:27018,mongodb-node04.default.svc.cluster.local:27018"
+            - "--port"
+            - "27017"
+          command:
+            - mongos
+          image: "mongo:3.4"
+          name: mgs01-node01
+          ports:
+            -
+              containerPort: 27017
+              hostPort: 27017
+              name: mgs01-node01
+      volumes:
+        -
+          name: vsphere-storage-mongoc01
+          persistentVolumeClaim:
+            claimName: pvcmongoc20gb-101
+        -
+          name: vsphere-storage-db-rsp01
+          persistentVolumeClaim:
+            claimName: pvc100gb-101
+        -
+          name: vsphere-storage-db-rss04
+          persistentVolumeClaim:
+            claimName: pvc100gb-102
+        -
+          name: vsphere-storage-db-rsa03
+          persistentVolumeClaim:
+            claimName: pvc5gb-101

--- a/kube-examples/mongodb-shards/node01-service.yaml
+++ b/kube-examples/mongodb-shards/node01-service.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: mongodb-node01
+    role: mongoshard
+    tier: backend
+  name: mongodb-node01
+spec:
+  ports:
+    -
+      name: arb03-node01
+      port: 27019
+      protocol: TCP
+    -
+      name: cfg01-node01
+      port: 27018
+      protocol: TCP
+    -
+      name: mgs01-node01
+      port: 27017
+      protocol: TCP
+    -
+      name: rsp01-node01
+      port: 27020
+      protocol: TCP
+    -
+      name: rss04-node01
+      port: 27021
+      protocol: TCP
+  selector:
+    app: mongodb-shard-node01
+    role: mongoshard
+    tier: backend

--- a/kube-examples/mongodb-shards/node02-deployment.yaml
+++ b/kube-examples/mongodb-shards/node02-deployment.yaml
@@ -1,0 +1,118 @@
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: mongodb-shard-node02
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: mongodb-shard-node02
+        role: mongoshard
+        tier: backend
+    spec:
+      containers:
+        -
+          args:
+            - "--replSet"
+            - rs04
+            - "--port"
+            - "27019"
+            - "--shardsvr"
+            - "--journal"
+          image: "mongo:3.4"
+          name: arb03-node02
+          ports:
+            -
+              containerPort: 27019
+              name: arb04-node02
+          volumeMounts:
+            -
+              mountPath: /data/db
+              name: vsphere-storage-db-rsa04
+        -
+          args:
+            - "--replSet"
+            - rs01
+            - "--port"
+            - "27021"
+            - "--shardsvr"
+            - "--journal"
+          image: "mongo:3.4"
+          name: rss01-node02
+          ports:
+            -
+              containerPort: 27021
+              name: rss01-node02
+          volumeMounts:
+            -
+              mountPath: /data/db
+              name: vsphere-storage-db-rss01
+        -
+          args:
+            - "--replSet"
+            - rs02
+            - "--port"
+            - "27020"
+            - "--shardsvr"
+            - "--journal"
+          image: "mongo:3.4"
+          name: rsp02-node02
+          ports:
+            -
+              containerPort: 27020
+              name: rsp02-node02
+          volumeMounts:
+            -
+              mountPath: /data/db
+              name: vsphere-storage-db-rsp02
+        -
+          args:
+            - "--configsvr"
+            - "--replSet"
+            - configReplSet01
+            - "--port"
+            - "27018"
+          image: "mongo:3.4"
+          name: cfg02-node02
+          ports:
+            -
+              containerPort: 27018
+              name: cfg02-node02
+          volumeMounts:
+            -
+              mountPath: /data/db
+              name: vsphere-storage-mongoc02
+        -
+          args:
+            - "--configdb"
+            - "configReplSet01/mongodb-node01.default.svc.cluster.local:27018,mongodb-node02.default.svc.cluster.local:27018,mongodb-node03.default.svc.cluster.local:27018,mongodb-node04.default.svc.cluster.local:27018"
+            - "--port"
+            - "27017"
+          command:
+            - mongos
+          image: "mongo:3.4"
+          name: mgs02-node02
+          ports:
+            -
+              containerPort: 27017
+              hostPort: 27017
+              name: mgs02-node02
+      volumes:
+        -
+          name: vsphere-storage-mongoc02
+          persistentVolumeClaim:
+            claimName: pvcmongoc20gb-201
+        -
+          name: vsphere-storage-db-rsp02
+          persistentVolumeClaim:
+            claimName: pvc100gb-201
+        -
+          name: vsphere-storage-db-rss01
+          persistentVolumeClaim:
+            claimName: pvc100gb-202
+        -
+          name: vsphere-storage-db-rsa04
+          persistentVolumeClaim:
+            claimName: pvc5gb-201

--- a/kube-examples/mongodb-shards/node02-service.yaml
+++ b/kube-examples/mongodb-shards/node02-service.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: mongodb-node02
+    role: mongoshard
+    tier: backend
+  name: mongodb-node02
+spec:
+  ports:
+    -
+      name: arb04-node02
+      port: 27019
+      protocol: TCP
+    -
+      name: cfg02-node02
+      port: 27018
+      protocol: TCP
+    -
+      name: mgs02-node02
+      port: 27017
+      protocol: TCP
+    -
+      name: rsp02-node02
+      port: 27020
+      protocol: TCP
+    -
+      name: rss01-node02
+      port: 27021
+      protocol: TCP
+  selector:
+    app: mongodb-shard-node02
+    role: mongoshard
+    tier: backend

--- a/kube-examples/mongodb-shards/node03-deployment.yaml
+++ b/kube-examples/mongodb-shards/node03-deployment.yaml
@@ -1,0 +1,120 @@
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: mongodb-shard-node03
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: mongodb-shard-node03
+        role: mongoshard
+        tier: backend
+    spec:
+      containers:
+        -
+          args:
+            - "--replSet"
+            - rs01
+            - "--port"
+            - "27019"
+            - "--shardsvr"
+            - "--journal"
+          image: "mongo:3.4"
+          name: arb01-node03
+          ports:
+            -
+              containerPort: 27019
+              name: arb01-node03
+          volumeMounts:
+            -
+              mountPath: /data/db
+              name: vsphere-storage-db-rsa01
+        -
+          args:
+            - "--storageEngine"
+            - wiredTiger
+            - "--replSet"
+            - rs02
+            - "--port"
+            - "27021"
+            - "--shardsvr"
+            - "--journal"
+          image: "mongo:3.4"
+          name: rss03-node03
+          ports:
+            -
+              containerPort: 27021
+              name: rss02-node03
+          volumeMounts:
+            -
+              mountPath: /data/db
+              name: vsphere-storage-db-rss02
+        -
+          args:
+            - "--replSet"
+            - rs03
+            - "--port"
+            - "27020"
+            - "--shardsvr"
+            - "--journal"
+          image: "mongo:3.4"
+          name: rsp03-node03
+          ports:
+            -
+              containerPort: 27020
+              name: rsp03-node03
+          volumeMounts:
+            -
+              mountPath: /data/db
+              name: vsphere-storage-db-rsp03
+        -
+          args:
+            - "--configsvr"
+            - "--replSet"
+            - configReplSet01
+            - "--port"
+            - "27018"
+          image: "mongo:3.4"
+          name: cfg03-node03
+          ports:
+            -
+              containerPort: 27018
+              name: cfg03-node03
+          volumeMounts:
+            -
+              mountPath: /data/db
+              name: vsphere-storage-mongoc03
+        -
+          args:
+            - "--configdb"
+            - "configReplSet01/mongodb-node01.default.svc.cluster.local:27018,mongodb-node02.default.svc.cluster.local:27018,mongodb-node03.default.svc.cluster.local:27018,mongodb-node04.default.svc.cluster.local:27018"
+            - "--port"
+            - "27017"
+          command:
+            - mongos
+          image: "mongo:3.4"
+          name: mgs03-node03
+          ports:
+            -
+              containerPort: 27017
+              hostPort: 27017
+              name: mgs03-node03
+      volumes:
+        -
+          name: vsphere-storage-mongoc03
+          persistentVolumeClaim:
+            claimName: pvcmongoc20gb-301
+        -
+          name: vsphere-storage-db-rsa01
+          persistentVolumeClaim:
+            claimName: pvc100gb-301
+        -
+          name: vsphere-storage-db-rss02
+          persistentVolumeClaim:
+            claimName: pvc100gb-302
+        -
+          name: vsphere-storage-db-rsp03
+          persistentVolumeClaim:
+            claimName: pvc5gb-301

--- a/kube-examples/mongodb-shards/node03-service.yaml
+++ b/kube-examples/mongodb-shards/node03-service.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: mongodb-node03
+    role: mongoshard
+    tier: backend
+  name: mongodb-node03
+spec:
+  ports:
+    -
+      name: arb01-node03
+      port: 27019
+      protocol: TCP
+    -
+      name: cfg03-node03
+      port: 27018
+      protocol: TCP
+    -
+      name: mgs03-node03
+      port: 27017
+      protocol: TCP
+    -
+      name: rsp03-node03
+      port: 27020
+      protocol: TCP
+    -
+      name: rss02-node03
+      port: 27021
+      protocol: TCP
+  selector:
+    app: mongodb-shard-node03
+    role: mongoshard
+    tier: backend

--- a/kube-examples/mongodb-shards/node04-deployment.yaml
+++ b/kube-examples/mongodb-shards/node04-deployment.yaml
@@ -1,0 +1,118 @@
+--- 
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: mongodb-shard-node04
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: mongodb-shard-node04
+        role: mongoshard
+        tier: backend
+    spec:
+      containers:
+        -
+          args:
+            - "--replSet"
+            - rs02
+            - "--port"
+            - "27019"
+            - "--shardsvr"
+            - "--journal"
+          image: "mongo:3.4"
+          name: arb02-node04
+          ports:
+            -
+              containerPort: 27019
+              name: arb02-node04
+          volumeMounts:
+            -
+              mountPath: /data/db
+              name: vsphere-storage-db-rsa02
+        -
+          args:
+            - "--replSet"
+            - rs03
+            - "--port"
+            - "27021"
+            - "--shardsvr"
+            - "--journal"
+          image: "mongo:3.4"
+          name: rss03-node04
+          ports:
+            -
+              containerPort: 27021
+              name: rss03-node04
+          volumeMounts:
+            -
+              mountPath: /data/db
+              name: vsphere-storage-db-rss03
+        -
+          args:
+            - "--replSet"
+            - rs04
+            - "--port"
+            - "27020"
+            - "--shardsvr"
+            - "--journal"
+          image: "mongo:3.4"
+          name: rsp04-node04
+          ports:
+            -
+              containerPort: 27020
+              name: rsp04-node04
+          volumeMounts:
+            -
+              mountPath: /data/db
+              name: vsphere-storage-db-rsp04
+        -
+          args:
+            - "--configsvr"
+            - "--replSet"
+            - configReplSet01
+            - "--port"
+            - "27018"
+          image: "mongo:3.4"
+          name: cfg04-node04
+          ports:
+            -
+              containerPort: 27018
+              name: cfg04-node04
+          volumeMounts:
+            -
+              mountPath: /data/db
+              name: vsphere-storage-mongoc04
+        -
+          args:
+            - "--configdb"
+            - "configReplSet01/mongodb-node01.default.svc.cluster.local:27018,mongodb-node02.default.svc.cluster.local:27018,mongodb-node03.default.svc.cluster.local:27018,mongodb-node04.default.svc.cluster.local:27018"
+            - "--port"
+            - "27017"
+          command:
+            - mongos
+          image: "mongo:3.4"
+          name: mgs04-node04
+          ports:
+            -
+              containerPort: 27017
+              hostPort: 27017
+              name: mgs04-node04
+      volumes:
+        -
+          name: vsphere-storage-mongoc04
+          persistentVolumeClaim:
+            claimName: pvcmongoc20gb-401
+        -
+          name: vsphere-storage-db-rsa02
+          persistentVolumeClaim:
+            claimName: pvc100gb-401
+        -
+          name: vsphere-storage-db-rss03
+          persistentVolumeClaim:
+            claimName: pvc100gb-402
+        -
+          name: vsphere-storage-db-rsp04
+          persistentVolumeClaim:
+            claimName: pvc5gb-401

--- a/kube-examples/mongodb-shards/node04-service.yaml
+++ b/kube-examples/mongodb-shards/node04-service.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: mongodb-node04
+    role: mongoshard
+    tier: backend
+  name: mongodb-node04
+spec:
+  ports:
+    -
+      name: arb02-node04
+      port: 27019
+      protocol: TCP
+    -
+      name: cfg04-node04
+      port: 27018
+      protocol: TCP
+    -
+      name: mgs04-node04
+      port: 27017
+      protocol: TCP
+    -
+      name: rsp04-node04
+      port: 27020
+      protocol: TCP
+    -
+      name: rss03-node04
+      port: 27021
+      protocol: TCP
+  selector:
+    app: mongodb-shard-node04
+    role: mongoshard
+    tier: backend

--- a/kube-examples/mongodb-shards/storage-volumes-node01.yaml
+++ b/kube-examples/mongodb-shards/storage-volumes-node01.yaml
@@ -1,0 +1,61 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pvcmongoc20gb-101
+  annotations:
+    volume.beta.kubernetes.io/storage-class: mongoshardsc
+  labels:
+    app: mongodb-shard-node01
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 20Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pvc100gb-101
+  annotations:
+    volume.beta.kubernetes.io/storage-class: mongoshardsc
+  labels:
+    app: mongodb-shard-node01
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pvc100gb-102
+  annotations:
+    volume.beta.kubernetes.io/storage-class: mongoshardsc
+  labels:
+    app: mongodb-shard-node01
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pvc5gb-101
+  annotations:
+    volume.beta.kubernetes.io/storage-class: mongoshardsc
+  labels:
+    app: mongodb-shard-node01
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+---

--- a/kube-examples/mongodb-shards/storage-volumes-node02.yaml
+++ b/kube-examples/mongodb-shards/storage-volumes-node02.yaml
@@ -1,0 +1,61 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pvcmongoc20gb-201
+  annotations:
+    volume.beta.kubernetes.io/storage-class: mongoshardsc
+  labels:
+    app: mongodb-shard-node02
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 20Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pvc100gb-201
+  annotations:
+    volume.beta.kubernetes.io/storage-class: mongoshardsc
+  labels:
+    app: mongodb-shard-node02
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pvc100gb-202
+  annotations:
+    volume.beta.kubernetes.io/storage-class: mongoshardsc
+  labels:
+    app: mongodb-shard-node02
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pvc5gb-201
+  annotations:
+    volume.beta.kubernetes.io/storage-class: mongoshardsc
+  labels:
+    app: mongodb-shard-node02
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+---

--- a/kube-examples/mongodb-shards/storage-volumes-node03.yaml
+++ b/kube-examples/mongodb-shards/storage-volumes-node03.yaml
@@ -1,0 +1,61 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pvcmongoc20gb-301
+  annotations:
+    volume.beta.kubernetes.io/storage-class: mongoshardsc
+  labels:
+    app: mongodb-shard-node03
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 20Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pvc100gb-301
+  annotations:
+    volume.beta.kubernetes.io/storage-class: mongoshardsc
+  labels:
+    app: mongodb-shard-node03
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pvc100gb-302
+  annotations:
+    volume.beta.kubernetes.io/storage-class: mongoshardsc
+  labels:
+    app: mongodb-shard-node03
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pvc5gb-301
+  annotations:
+    volume.beta.kubernetes.io/storage-class: mongoshardsc
+  labels:
+    app: mongodb-shard-node03
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+---

--- a/kube-examples/mongodb-shards/storage-volumes-node04.yaml
+++ b/kube-examples/mongodb-shards/storage-volumes-node04.yaml
@@ -1,0 +1,61 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pvcmongoc20gb-401
+  annotations:
+    volume.beta.kubernetes.io/storage-class: mongoshardsc
+  labels:
+    app: mongodb-shard-node04
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 20Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pvc100gb-401
+  annotations:
+    volume.beta.kubernetes.io/storage-class: mongoshardsc
+  labels:
+    app: mongodb-shard-node04
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pvc100gb-402
+  annotations:
+    volume.beta.kubernetes.io/storage-class: mongoshardsc
+  labels:
+    app: mongodb-shard-node04
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pvc5gb-401
+  annotations:
+    volume.beta.kubernetes.io/storage-class: mongoshardsc
+  labels:
+    app: mongodb-shard-node04
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+---

--- a/kube-examples/mongodb-shards/storageclass.yaml
+++ b/kube-examples/mongodb-shards/storageclass.yaml
@@ -1,0 +1,7 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: mongoshardsc
+provisioner: kubernetes.io/vsphere-volume
+parameters:
+    diskformat: thin


### PR DESCRIPTION
YAMLs for

- GuestBook
- minio stateful set distributed
- minio standalone
- mongodb-shards - 4 node deployment 


I have tested deploying these YAMLs on Kubernetes v1.7.0-beta.2

**I am not authorized to push to this branch - "kube-examples", as it is protected branch.** 
cc:  @luomiao @BaluDontu @rohitjogvmw @tusharnt 

