### PR TITLE
Multi-VC support - Part 1

### DIFF
--- a/pkg/cloudprovider/cloud.go
+++ b/pkg/cloudprovider/cloud.go
@@ -138,6 +138,10 @@ type Instances interface {
 	// CurrentNodeName returns the name of the node we are currently running on
 	// On most clouds (e.g. GCE) this is the hostname, so we provide the hostname
 	CurrentNodeName(hostname string) (types.NodeName, error)
+	// Notification to the cloud provider when node is registered
+	NodeRegistered(nodes *v1.Node)
+	// Notification to the cloud provider when node is unregistered
+	NodeUnregistered(nodes *v1.Node)
 }
 
 // Route is a representation of an advanced routing rule.

--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -971,6 +971,16 @@ func (c *Cloud) Routes() (cloudprovider.Routes, bool) {
 	return c, true
 }
 
+// Notification handler when node is registered.
+func (c *Cloud) NodeRegistered(node *v1.Node) {
+
+}
+
+// Notification handler when node is unregistered.
+func (c *Cloud) NodeUnregistered(node *v1.Node) {
+
+}
+
 // NodeAddresses is an implementation of Instances.NodeAddresses.
 func (c *Cloud) NodeAddresses(name types.NodeName) ([]v1.NodeAddress, error) {
 	if c.selfAWSInstance.nodeName == name || len(name) == 0 {

--- a/pkg/cloudprovider/providers/azure/azure.go
+++ b/pkg/cloudprovider/providers/azure/azure.go
@@ -24,6 +24,7 @@ import (
 	"io/ioutil"
 	"time"
 
+	"k8s.io/api/core/v1"
 	"k8s.io/client-go/util/flowcontrol"
 	"k8s.io/kubernetes/pkg/cloudprovider"
 	"k8s.io/kubernetes/pkg/controller"
@@ -433,4 +434,14 @@ func initDiskControllers(az *Cloud) error {
 	az.controllerCommon = common
 
 	return nil
+}
+
+// Notification handler when node is registered.
+func (az *Cloud) NodeRegistered(node *v1.Node) {
+
+}
+
+// Notification handler when node is unregistered.
+func (az *Cloud) NodeUnregistered(node *v1.Node) {
+
 }

--- a/pkg/cloudprovider/providers/cloudstack/cloudstack.go
+++ b/pkg/cloudprovider/providers/cloudstack/cloudstack.go
@@ -23,6 +23,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/xanzy/go-cloudstack/cloudstack"
 	"gopkg.in/gcfg.v1"
+	"k8s.io/api/core/v1"
 	"k8s.io/kubernetes/pkg/cloudprovider"
 	"k8s.io/kubernetes/pkg/controller"
 )
@@ -124,4 +125,14 @@ func (cs *CSCloud) ScrubDNS(nameservers, searches []string) (nsOut, srchOut []st
 func (cs *CSCloud) GetZone() (cloudprovider.Zone, error) {
 	glog.V(2).Infof("Current zone is %v", cs.zone)
 	return cloudprovider.Zone{Region: cs.zone}, nil
+}
+
+// Notification handler when node is registered.
+func (cs *CSCloud) NodeRegistered(node *v1.Node) {
+
+}
+
+// Notification handler when node is unregistered.
+func (cs *CSCloud) NodeUnregistered(node *v1.Node) {
+
 }

--- a/pkg/cloudprovider/providers/fake/fake.go
+++ b/pkg/cloudprovider/providers/fake/fake.go
@@ -290,3 +290,13 @@ func (f *FakeCloud) DeleteRoute(clusterName string, route *cloudprovider.Route) 
 	delete(f.RouteMap, name)
 	return nil
 }
+
+// Notification handler when node is registered.
+func (f *FakeCloud) NodeRegistered(node *v1.Node) {
+
+}
+
+// Notification handler when node is unregistered.
+func (f *FakeCloud) NodeUnregistered(node *v1.Node) {
+
+}

--- a/pkg/cloudprovider/providers/gce/gce.go
+++ b/pkg/cloudprovider/providers/gce/gce.go
@@ -29,6 +29,7 @@ import (
 
 	"cloud.google.com/go/compute/metadata"
 
+	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/flowcontrol"
@@ -542,4 +543,14 @@ func (manager *GCEServiceManager) DeleteDisk(
 
 func (manager *GCEServiceManager) WaitForZoneOp(op *compute.Operation, zone string, mc *metricContext) error {
 	return manager.gce.waitForZoneOp(op, zone, mc)
+}
+
+// Notification handler when node is registered.
+func (gce *GCECloud) NodeRegistered(node *v1.Node) {
+
+}
+
+// Notification handler when node is unregistered.
+func (gce *GCECloud) NodeUnregistered(node *v1.Node) {
+
 }

--- a/pkg/cloudprovider/providers/openstack/openstack_instances.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_instances.go
@@ -212,3 +212,13 @@ func instanceIDFromProviderID(providerID string) (instanceID string, err error) 
 
 	return parsedID.Host, nil
 }
+
+// Notification handler when node is registered.
+func (i *Instances) NodeRegistered(node *v1.Node) {
+
+}
+
+// Notification handler when node is unregistered.
+func (i *Instances) NodeUnregistered(node *v1.Node) {
+
+}

--- a/pkg/cloudprovider/providers/ovirt/ovirt.go
+++ b/pkg/cloudprovider/providers/ovirt/ovirt.go
@@ -312,3 +312,13 @@ func (v *OVirtCloud) CurrentNodeName(hostname string) (types.NodeName, error) {
 func (v *OVirtCloud) AddSSHKeyToAllInstances(user string, keyData []byte) error {
 	return errors.New("unimplemented")
 }
+
+// Notification handler when node is registered.
+func (v *OVirtCloud) NodeRegistered(node *v1.Node) {
+
+}
+
+// Notification handler when node is unregistered.
+func (v *OVirtCloud) NodeUnregistered(node *v1.Node) {
+
+}

--- a/pkg/cloudprovider/providers/photon/photon.go
+++ b/pkg/cloudprovider/providers/photon/photon.go
@@ -720,3 +720,13 @@ func (pc *PCCloud) DeleteDisk(pdID string) error {
 
 	return nil
 }
+
+// Notification handler when node is registered.
+func (pc *PCCloud) NodeRegistered(node *v1.Node) {
+
+}
+
+// Notification handler when node is unregistered.
+func (pc *PCCloud) NodeUnregistered(node *v1.Node) {
+
+}

--- a/pkg/cloudprovider/providers/rackspace/rackspace.go
+++ b/pkg/cloudprovider/providers/rackspace/rackspace.go
@@ -759,3 +759,13 @@ func (rs *Rackspace) DisksAreAttached(instanceID string, volumeIDs []string) (ma
 func (rs *Rackspace) ShouldTrustDevicePath() bool {
 	return true
 }
+
+// Notification handler when node is registered.
+func (i *Instances) NodeRegistered(node *v1.Node) {
+
+}
+
+// Notification handler when node is unregistered.
+func (i *Instances) NodeUnregistered(node *v1.Node) {
+
+}

--- a/pkg/cloudprovider/providers/vsphere/vsphere.go
+++ b/pkg/cloudprovider/providers/vsphere/vsphere.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"os"
 	"path"
 	"path/filepath"
 	"runtime"
@@ -63,10 +64,9 @@ var cleanUpDummyVMLock sync.RWMutex
 
 // VSphere is an implementation of cloud provider Interface for VSphere.
 type VSphere struct {
-	conn *vclib.VSphereConnection
-	cfg  *VSphereConfig
-	// InstanceID of the server where this VSphere object is instantiated.
-	localInstanceID string
+	conn     *vclib.VSphereConnection
+	cfg      *VSphereConfig
+	hostName string
 }
 
 // VSphereConfig information that is used by vSphere Cloud Provider to connect to VC
@@ -83,9 +83,9 @@ type VSphereConfig struct {
 		// True if vCenter uses self-signed cert.
 		InsecureFlag bool `gcfg:"insecure-flag"`
 		// Datacenter in which VMs are located.
-		Datacenter string `gcfg:"datacenter"`
+		Datacenters string `gcfg:"datacenters"`
 		// Datastore in which vmdks are stored.
-		Datastore string `gcfg:"datastore"`
+		DeafultDatastore string `gcfg:"default-datastore"`
 		// WorkingDir is path where VMs can be found.
 		WorkingDir string `gcfg:"working-dir"`
 		// Soap round tripper count (retries = RoundTripper - 1)
@@ -98,6 +98,23 @@ type VSphereConfig struct {
 		// Combining the WorkingDir and VMName can form a unique InstanceID.
 		// When vm-name is set, no username/password is required on worker nodes.
 		VMName string `gcfg:"vm-name"`
+	}
+
+	VirtualCenter map[string]*struct {
+		// vCenter username.
+		User string `gcfg:"user"`
+		// vCenter password in clear text.
+		Password string `gcfg:"password"`
+		// vCenter port.
+		VCenterPort string `gcfg:"port"`
+		// True if vCenter uses self-signed cert.
+		InsecureFlag bool `gcfg:"insecure-flag"`
+		// Datacenter in which VMs are located.
+		Datacenters string `gcfg:"datacenters"`
+		// WorkingDir is path where VMs can be found.
+		WorkingDir string `gcfg:"working-dir"`
+		// Soap round tripper count (retries = RoundTripper - 1)
+		RoundTripperCount uint `gcfg:"soap-roundtrip-count"`
 	}
 
 	Network struct {
@@ -151,19 +168,39 @@ func readConfig(config io.Reader) (VSphereConfig, error) {
 func init() {
 	vclib.RegisterMetrics()
 	cloudprovider.RegisterCloudProvider(ProviderName, func(config io.Reader) (cloudprovider.Interface, error) {
+		// If vSphere.conf file is not present then it is worker node.
+		if config == nil {
+			return newWorkerNode()
+		}
 		cfg, err := readConfig(config)
 		if err != nil {
 			return nil, err
 		}
-		return newVSphere(cfg)
+		return newControllerNode(cfg)
 	})
 }
 
 // Initialize passes a Kubernetes clientBuilder interface to the cloud provider
 func (vs *VSphere) Initialize(clientBuilder controller.ControllerClientBuilder) {}
 
-func newVSphere(cfg VSphereConfig) (*VSphere, error) {
+// Creates new worker node interface and returns
+func newWorkerNode() (*VSphere, error) {
 	var err error
+	vs := VSphere{}
+	vs.hostName, err = os.Hostname()
+	if err != nil {
+		glog.Errorf("Failed to get hostname. err: %+v", err)
+		return nil, err
+	}
+
+	return &vs, nil
+}
+
+// Creates new Contreoller node interface and returns
+func newControllerNode(cfg VSphereConfig) (*VSphere, error) {
+	var err error
+	// TODO: Remove this log as it will print VC credentials in log.
+	glog.V(4).Infof("cfg is %+v", cfg)
 	if cfg.Disk.SCSIControllerType == "" {
 		cfg.Disk.SCSIControllerType = vclib.PVSCSIControllerType
 	} else if !vclib.CheckControllerSupported(cfg.Disk.SCSIControllerType) {
@@ -194,40 +231,18 @@ func newVSphere(cfg VSphereConfig) (*VSphere, error) {
 		Insecure:          cfg.Global.InsecureFlag,
 		RoundTripperCount: cfg.Global.RoundTripperCount,
 	}
-	var instanceID string
 
-	if cfg.Global.VMName == "" {
-		// if VMName is not set in the cloud config file, each nodes (including worker nodes) need credentials to obtain VMName from vCenter
-		glog.V(4).Infof("Cannot find VMName from cloud config file, start obtaining it from vCenter")
-		// Create context
-		ctx, cancel := context.WithCancel(context.TODO())
-		defer cancel()
-		err = vSphereConn.Connect(ctx)
-		if err != nil {
-			glog.Errorf("Failed to connect to vSphere")
-			return nil, err
-		}
-		dc, err := vclib.GetDatacenter(ctx, &vSphereConn, cfg.Global.Datacenter)
-		if err != nil {
-			return nil, err
-		}
-		vm, err := dc.GetVMByUUID(ctx, cfg.Global.VMUUID)
-		if err != nil {
-			return nil, err
-		}
-		vmName, err := vm.ObjectName(ctx)
-		if err != nil {
-			return nil, err
-		}
-		instanceID = vmName
-	} else {
-		instanceID = cfg.Global.VMName
-	}
 	vs := VSphere{
-		conn:            &vSphereConn,
-		cfg:             &cfg,
-		localInstanceID: instanceID,
+		conn: &vSphereConn,
+		cfg:  &cfg,
 	}
+
+	vs.hostName, err = os.Hostname()
+	if err != nil {
+		glog.Errorf("Failed to get hostname. err: %+v", err)
+		return nil, err
+	}
+
 	runtime.SetFinalizer(&vs, logout)
 	return &vs, nil
 }
@@ -299,47 +314,12 @@ func (vs *VSphere) getVMByName(ctx context.Context, nodeName k8stypes.NodeName) 
 // NodeAddresses is an implementation of Instances.NodeAddresses.
 func (vs *VSphere) NodeAddresses(nodeName k8stypes.NodeName) ([]v1.NodeAddress, error) {
 	// Get local IP addresses if node is local node
-	if vs.localInstanceID == nodeNameToVMName(nodeName) {
+	if vs.hostName == nodeNameToVMName(nodeName) {
 		return getLocalIP()
 	}
-	addrs := []v1.NodeAddress{}
-	// Create context
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	// Ensure client is logged in and session is valid
-	err := vs.conn.Connect(ctx)
-	if err != nil {
-		return nil, err
-	}
-	vm, err := vs.getVMByName(ctx, nodeName)
-	if err != nil {
-		glog.Errorf("Failed to get VM object for node: %q. err: +%v", nodeNameToVMName(nodeName), err)
-		return nil, err
-	}
-	vmMoList, err := vm.Datacenter.GetVMMoList(ctx, []*vclib.VirtualMachine{vm}, []string{"guest.net"})
-	if err != nil {
-		glog.Errorf("Failed to get VM Managed object with property guest.net for node: %q. err: +%v", nodeNameToVMName(nodeName), err)
-		return nil, err
-	}
-	// retrieve VM's ip(s)
-	for _, v := range vmMoList[0].Guest.Net {
-		if vs.cfg.Network.PublicNetwork == v.Network {
-			for _, ip := range v.IpAddress {
-				if net.ParseIP(ip).To4() != nil {
-					v1helper.AddToNodeAddresses(&addrs,
-						v1.NodeAddress{
-							Type:    v1.NodeExternalIP,
-							Address: ip,
-						}, v1.NodeAddress{
-							Type:    v1.NodeInternalIP,
-							Address: ip,
-						},
-					)
-				}
-			}
-		}
-	}
-	return addrs, nil
+
+	// TODO: Need to see what to do if nodename and localNodeName are not matching.
+	return nil, cloudprovider.InstanceNotFound
 }
 
 // NodeAddressesByProviderID returns the node addresses of an instances with the specified unique providerID
@@ -357,7 +337,7 @@ func (vs *VSphere) AddSSHKeyToAllInstances(user string, keyData []byte) error {
 
 // CurrentNodeName gives the current node name
 func (vs *VSphere) CurrentNodeName(hostname string) (k8stypes.NodeName, error) {
-	return vmNameToNodeName(vs.localInstanceID), nil
+	return vmNameToNodeName(vs.hostName), nil
 }
 
 // nodeNameToVMName maps a NodeName to the vmware infrastructure name
@@ -377,30 +357,11 @@ func (vs *VSphere) ExternalID(nodeName k8stypes.NodeName) (string, error) {
 
 // InstanceID returns the cloud provider ID of the node with the specified Name.
 func (vs *VSphere) InstanceID(nodeName k8stypes.NodeName) (string, error) {
-	if vs.localInstanceID == nodeNameToVMName(nodeName) {
-		return vs.cfg.Global.WorkingDir + "/" + vs.localInstanceID, nil
+	if vs.hostName == nodeNameToVMName(nodeName) {
+		return vs.hostName, nil
 	}
-	// Create context
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	// Ensure client is logged in and session is valid
-	err := vs.conn.Connect(ctx)
-	if err != nil {
-		return "", err
-	}
-	vm, err := vs.getVMByName(ctx, nodeName)
-	if err != nil {
-		glog.Errorf("Failed to get VM object for node: %q. err: +%v", nodeNameToVMName(nodeName), err)
-		return "", err
-	}
-	nodeExist, err := vm.Exists(ctx)
-	if err != nil {
-		glog.Errorf("Failed to check whether node %q exist. err: %+v.", nodeNameToVMName(nodeName), err)
-		return "", err
-	}
-	if nodeExist {
-		return "/" + vm.InventoryPath, nil
-	}
+
+	// TODO: Need to see what to do if nodename and localNodeName are not matching.
 	return "", cloudprovider.InstanceNotFound
 }
 
@@ -449,7 +410,7 @@ func (vs *VSphere) ScrubDNS(nameservers, searches []string) (nsOut, srchOut []st
 func (vs *VSphere) AttachDisk(vmDiskPath string, storagePolicyID string, nodeName k8stypes.NodeName) (diskUUID string, err error) {
 	attachDiskInternal := func(vmDiskPath string, storagePolicyID string, nodeName k8stypes.NodeName) (diskUUID string, err error) {
 		if nodeName == "" {
-			nodeName = vmNameToNodeName(vs.localInstanceID)
+			nodeName = vmNameToNodeName(vs.hostName)
 		}
 		// Create context
 		ctx, cancel := context.WithCancel(context.Background())
@@ -481,7 +442,7 @@ func (vs *VSphere) AttachDisk(vmDiskPath string, storagePolicyID string, nodeNam
 func (vs *VSphere) DetachDisk(volPath string, nodeName k8stypes.NodeName) error {
 	detachDiskInternal := func(volPath string, nodeName k8stypes.NodeName) error {
 		if nodeName == "" {
-			nodeName = vmNameToNodeName(vs.localInstanceID)
+			nodeName = vmNameToNodeName(vs.hostName)
 		}
 		// Create context
 		ctx, cancel := context.WithCancel(context.Background())
@@ -514,7 +475,7 @@ func (vs *VSphere) DiskIsAttached(volPath string, nodeName k8stypes.NodeName) (b
 	diskIsAttachedInternal := func(volPath string, nodeName k8stypes.NodeName) (bool, error) {
 		var vSphereInstance string
 		if nodeName == "" {
-			vSphereInstance = vs.localInstanceID
+			vSphereInstance = vs.hostName
 			nodeName = vmNameToNodeName(vSphereInstance)
 		} else {
 			vSphereInstance = nodeNameToVMName(nodeName)
@@ -568,7 +529,7 @@ func (vs *VSphere) DisksAreAttached(volPaths []string, nodeName k8stypes.NodeNam
 		}
 		var vSphereInstance string
 		if nodeName == "" {
-			vSphereInstance = vs.localInstanceID
+			vSphereInstance = vs.hostName
 			nodeName = vmNameToNodeName(vSphereInstance)
 		} else {
 			vSphereInstance = nodeNameToVMName(nodeName)
@@ -745,4 +706,14 @@ func (vs *VSphere) DeleteVolume(vmDiskPath string) error {
 	err := deleteVolumeInternal(vmDiskPath)
 	vclib.RecordvSphereMetric(vclib.OperationDeleteVolume, requestTime, err)
 	return err
+}
+
+// Notification handler when node is registered.
+func (vs *VSphere) NodeRegistered(node *v1.Node) {
+	glog.V(4).Infof("Node Registered: %+v", node)
+}
+
+// Notification handler when node is unregistered.
+func (vs *VSphere) NodeUnregistered(node *v1.Node) {
+	glog.V(4).Infof("Node Unregistered: %+v", node)
 }

--- a/pkg/cloudprovider/providers/vsphere/vsphere_util.go
+++ b/pkg/cloudprovider/providers/vsphere/vsphere_util.go
@@ -54,9 +54,9 @@ func GetVSphere() (*VSphere, error) {
 	}
 	vSphereConn.GoVmomiClient = client
 	vs := &VSphere{
-		conn:            vSphereConn,
-		cfg:             cfg,
-		localInstanceID: "",
+		conn:     vSphereConn,
+		cfg:      cfg,
+		hostName: "",
 	}
 	runtime.SetFinalizer(vs, logout)
 	return vs, nil
@@ -241,7 +241,7 @@ func getPbmCompatibleDatastore(ctx context.Context, client *vim25.Client, storag
 
 func (vs *VSphere) setVMOptions(ctx context.Context, dc *vclib.Datacenter) (*vclib.VMOptions, error) {
 	var vmOptions vclib.VMOptions
-	vm, err := dc.GetVMByPath(ctx, vs.cfg.Global.WorkingDir+"/"+vs.localInstanceID)
+	vm, err := dc.GetVMByPath(ctx, vs.cfg.Global.WorkingDir+"/"+vs.hostName)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/node/nodecontroller.go
+++ b/pkg/controller/node/nodecontroller.go
@@ -556,12 +556,20 @@ func (nc *NodeController) monitorNodeStatus() error {
 		} else {
 			nc.cancelPodEviction(added[i])
 		}
+		instance, isSupported := nc.cloud.Instances()
+		if isSupported {
+			instance.NodeRegistered(added[i])
+		}
 	}
 
 	for i := range deleted {
 		glog.V(1).Infof("NodeController observed a Node deletion: %v", deleted[i].Name)
 		recordNodeEvent(nc.recorder, deleted[i].Name, string(deleted[i].UID), v1.EventTypeNormal, "RemovingNode", fmt.Sprintf("Removing Node %v from NodeController", deleted[i].Name))
 		delete(nc.knownNodeSet, deleted[i].Name)
+		instance, isSupported := nc.cloud.Instances()
+		if isSupported {
+			instance.NodeUnregistered(deleted[i])
+		}
 	}
 
 	zoneToNodeConditions := map[string][]*v1.NodeCondition{}


### PR DESCRIPTION

Code changes for  below changes

 - Send hostname from each node. 
 - If config file is not present then Initialize WorkerNode 
 - Modified gcfg config file read struct to make use of new format 
 - CloudProvider calls each provider when node is registered / unregistered


Testing done:
   - After creating kubernetes cluster on vsphere, manually changed hostname and VMName.
     After rebooting workernode, I could see that new hostname node got registered
   - For new node addition, on master verified that NodeRegistered interfaced got called
   - On one of the worker node modified  /etc/systemd/system/multi-user.target.wants/kubelet.service and removed cloud-config parameter to kubectl and restarted kubelet. Node was shown in ReadyState once kubelet was started.

Below is the sample output after all above changes :

```
kubectl get nodes
NAME          STATUS                     AGE       VERSION
master        Ready,SchedulingDisabled   1d        v1.6.0-alpha.0.13043+2211945f3cad85
node2         Ready                      1d        v1.6.0-alpha.0.13043+2211945f3cad85
node3         Ready                      1d        v1.6.0-alpha.0.13043+2211945f3cad85
node4         Ready                      1d        v1.6.0-alpha.0.13043+2211945f3cad85
rohit-node1   Ready                      18m       v1.6.0-alpha.0.13046+389d9886d96fd4
```


@divyenpatel, @luomiao, @tusharnt, @BaluDontu, @SandeepPissay 