### PR TITLE
Fixing Minio YAMLs

### DIFF
--- a/kube-examples/minio/distributed/minio-distributed-headless-service.yaml
+++ b/kube-examples/minio/distributed/minio-distributed-headless-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio
+  labels:
+    app: minio
+spec:
+  clusterIP: None
+  ports:
+    - port: 9000
+      name: minio
+  selector:
+    app: minio

--- a/kube-examples/minio/distributed/minio-distributed-statefulset.yaml
+++ b/kube-examples/minio/distributed/minio-distributed-statefulset.yaml
@@ -1,17 +1,3 @@
-apiVersion: v1
-kind: Service
-metadata:
-  name: minio
-  labels:
-    app: minio
-spec:
-  clusterIP: None
-  ports:
-    - port: 9000
-      name: minio
-  selector:
-    app: minio
----
 apiVersion: apps/v1beta1
 kind: StatefulSet
 metadata:
@@ -61,4 +47,3 @@ spec:
       resources:
         requests:
           storage: 5Gi
-


### PR DESCRIPTION
@msterin was trying out Minio setup steps from the documentation - http://vmware.github.io/docker-volume-vsphere/kubernetes/minio.html and we observed yaml file (`minio-distributed-headless-service.yaml`) to Create Minio headless Service is not available in the repository.

YAML content for this file is avaialble in ` minio-distributed-statefulset.yaml`.

This PR is moving YAML content to appropriate file - `minio-distributed-headless-service.yaml`
such that https://github.com/vmware/kubernetes/tree/kube-examples/kube-examples/minio/distributed/minio-distributed-headless-service.yaml?raw=true does not throw 404.

Please Review: @BaluDontu @luomiao @tusharnt 

 