### PR TITLE
Simplify UX to Enable VCP: Fixed Issues observed during testing

### DIFF
--- a/enable-vcp-image/Dockerfile
+++ b/enable-vcp-image/Dockerfile
@@ -1,6 +1,10 @@
-FROM ubuntu:16.10
-MAINTAINER cna-storage@vmware.com
+FROM gliderlabs/alpine
+MAINTAINER containers@vmware.com
 
+RUN apk add --no-cache bash jq py-pip openssl go git libc-dev
+ENV GOPATH /go
+ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
+RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
 
 #### ---- Installer Files ---- ####
 ARG INSTALLER=install.sh

--- a/enable-vcp-image/enable-vcp-scripts/common_func.sh
+++ b/enable-vcp-image/enable-vcp-scripts/common_func.sh
@@ -9,12 +9,12 @@ DAEMONSET_SCRIPT_PHASE5="[PHASE 5] Create vSphere.conf file"
 DAEMONSET_SCRIPT_PHASE6="[PHASE 6] Update Manifest files and service configuration file"
 DAEMONSET_SCRIPT_PHASE7="[PHASE 7] Restart Kubelet Service"
 DAEMONSET_SCRIPT_PHASE8="COMPLETE"
-
 DAEMONSET_PHASE_RUNNING="RUNNING"
 DAEMONSET_PHASE_FAILED="FAILED"
 DAEMONSET_PHASE_COMPLETE="COMPLETE"
 
 read_secret_keys() {
+    export k8s_secret_config_backup=`cat /secret-volume/configuration_backup_directory; echo;`
     export k8s_secret_vc_admin_username=`cat /secret-volume/vc_admin_username; echo;`
     export k8s_secret_vc_admin_password=`cat /secret-volume/vc_admin_password; echo;`
     export k8s_secret_vcp_username=`cat /secret-volume/vcp_username; echo;`

--- a/enable-vcp-image/enable-vcp-scripts/common_func.sh
+++ b/enable-vcp-image/enable-vcp-scripts/common_func.sh
@@ -15,7 +15,6 @@ DAEMONSET_PHASE_FAILED="FAILED"
 DAEMONSET_PHASE_COMPLETE="COMPLETE"
 
 read_secret_keys() {
-    export k8s_secret_master_node_name=`cat /secret-volume/master_node_name; echo;`
     export k8s_secret_vc_admin_username=`cat /secret-volume/vc_admin_username; echo;`
     export k8s_secret_vc_admin_password=`cat /secret-volume/vc_admin_password; echo;`
     export k8s_secret_vcp_username=`cat /secret-volume/vcp_username; echo;`
@@ -100,36 +99,42 @@ locate_validate_and_backup_files() {
     BACKUP_DIR=$2
     POD_NAME=$3
 
-    ls $CONFIG_FILE &> /dev/null
-    if [ $? -eq 0 ]; then
-        echo "[INFO] Found file:" $CONFIG_FILE
-        if [ "${CONFIG_FILE##*.}" == "json" ]; then
-            jq "." $CONFIG_FILE &> /dev/null
+    file_name="${CONFIG_FILE##*/}"
+    ls $BACKUP_DIR/$file_name &> /dev/null
+    if [ $? -ne 0 ]; then
+            ls $CONFIG_FILE &> /dev/null
             if [ $? -eq 0 ]; then
-                echo "[INFO] Verified " $CONFIG_FILE " is a Valid JSON file"
-            else
-                ERROR_MSG="Failed to Validate JSON for file:" $CONFIG_FILE
-                update_VcpConigStatus "$POD_NAME" "$PHASE" "$DAEMONSET_PHASE_FAILED" "$ERROR_MSG"
-                exit $ERROR_FAIL_TO_PARSE_CONFIG_FILE
+                echo "[INFO] Found file:" $CONFIG_FILE
+                if [ "${CONFIG_FILE##*.}" == "json" ]; then
+                    jq "." $CONFIG_FILE &> /dev/null
+                    if [ $? -eq 0 ]; then
+                        echo "[INFO] Verified " $CONFIG_FILE " is a Valid JSON file"
+                    else
+                        ERROR_MSG="Failed to Validate JSON for file:" $CONFIG_FILE
+                        update_VcpConigStatus "$POD_NAME" "$PHASE" "$DAEMONSET_PHASE_FAILED" "$ERROR_MSG"
+                        exit $ERROR_FAIL_TO_PARSE_CONFIG_FILE
+                    fi
+                elif [ "${CONFIG_FILE##*.}" == "yaml" ]; then
+                    j2y -r $CONFIG_FILE &> /dev/null
+                    if [ $? -eq 0 ]; then
+                        echo "[INFO] Verified " $CONFIG_FILE " is a Valid YAML file"
+                    else
+                        ERROR_MSG="Failed to Validate YAML for file:" $CONFIG_FILE
+                        update_VcpConigStatus "$POD_NAME" "$PHASE" "$DAEMONSET_PHASE_FAILED" "$ERROR_MSG"
+                        exit $ERROR_FAIL_TO_PARSE_CONFIG_FILE
+                    fi
+                fi
+                cp $CONFIG_FILE $BACKUP_DIR
+                if [ $? -eq 0 ]; then
+                    echo "[INFO] Successfully backed up " $CONFIG_FILE at $BACKUP_DIR
+                else
+                    ERROR_MSG="Failed to back up " $CONFIG_FILE at $BACKUP_DIR
+                    update_VcpConigStatus "$POD_NAME" "$PHASE" "$DAEMONSET_PHASE_FAILED" "$ERROR_MSG"
+                    exit $ERROR_FAIL_TO_BACKUP_FILE
+                fi
             fi
-        elif [ "${CONFIG_FILE##*.}" == "yaml" ]; then
-            j2y -r $CONFIG_FILE &> /dev/null
-            if [ $? -eq 0 ]; then
-                echo "[INFO] Verified " $CONFIG_FILE " is a Valid YAML file"
-            else
-                ERROR_MSG="Failed to Validate YAML for file:" $CONFIG_FILE
-                update_VcpConigStatus "$POD_NAME" "$PHASE" "$DAEMONSET_PHASE_FAILED" "$ERROR_MSG"
-                exit $ERROR_FAIL_TO_PARSE_CONFIG_FILE
-            fi
-        fi
-        cp $CONFIG_FILE $BACKUP_DIR
-        if [ $? -eq 0 ]; then
-            echo "[INFO] Successfully backed up " $CONFIG_FILE at $BACKUP_DIR
-        else
-            ERROR_MSG="Failed to back up " $CONFIG_FILE at $BACKUP_DIR
-            update_VcpConigStatus "$POD_NAME" "$PHASE" "$DAEMONSET_PHASE_FAILED" "$ERROR_MSG"
-            exit $ERROR_FAIL_TO_BACKUP_FILE
-        fi
+    else
+        echo "[INFO] Skipping Backup - File: ${file_name} already present at the back up directory: ${BACKUP_DIR}"
     fi
 }
 
@@ -141,8 +146,9 @@ add_flags_to_manifest_file() {
     commandflag=`jq '.spec.containers[0].command' ${MANIFEST_FILE} | grep "\-\-cloud-provider=vsphere"`
     if [ -z "$commandflag" ]; then
         # adding --cloud-provider=vsphere flag to the manifest file
-        jq '.spec.containers[0].command |= .+ ["--cloud-provider=vsphere"]' ${MANIFEST_FILE} > ${MANIFEST_FILE}
+        jq '.spec.containers[0].command |= .+ ["--cloud-provider=vsphere"]' ${MANIFEST_FILE} > ${MANIFEST_FILE}.tmp
         if [ $? -eq 0 ]; then
+            mv ${MANIFEST_FILE}.tmp ${MANIFEST_FILE}
             echo "[INFO] Sucessfully added --cloud-provider=vsphere flag to ${MANIFEST_FILE}"
         else
             ERROR_MSG="Failed to add --cloud-provider=vsphere flag to ${MANIFEST_FILE}"
@@ -156,9 +162,10 @@ add_flags_to_manifest_file() {
     commandflag=`jq '.spec.containers[0].command' ${MANIFEST_FILE} | grep "\-\-cloud-config=${k8s_secret_vcp_configuration_file_location}/vsphere.conf"`
     if [ -z "$commandflag" ]; then
         # adding --cloud-config=/k8s_secret_vcp_configuration_file_location/vsphere.conf flag to the manifest file
-        jq '.spec.containers[0].command |= .+ ["--cloud-config='${k8s_secret_vcp_configuration_file_location}'/vsphere.conf"]' ${MANIFEST_FILE} > ${MANIFEST_FILE}
+        jq '.spec.containers[0].command |= .+ ["--cloud-config='${k8s_secret_vcp_configuration_file_location}'/vsphere.conf"]' ${MANIFEST_FILE} > ${MANIFEST_FILE}.tmp
         if [ $? -eq 0 ]; then
-            echo "[INFO] Sucessfully added --cloud-config='${k8s_secret_vcp_configuration_file_location}'/vsphere.conf flag to ${MANIFEST_FILE}"
+            mv ${MANIFEST_FILE}.tmp ${MANIFEST_FILE}
+            echo "[INFO] Sucessfully added --cloud-config='${k8s_secret_vcp_configuration_file_location}/vsphere.conf' flag to ${MANIFEST_FILE}"
         else
             ERROR_MSG="Failed to add --cloud-config='${k8s_secret_vcp_configuration_file_location}'/vsphere.conf flag to ${MANIFEST_FILE}"
             update_VcpConigStatus "$POD_NAME" "$PHASE" "$DAEMONSET_PHASE_FAILED" "$ERROR_MSG"
@@ -166,6 +173,35 @@ add_flags_to_manifest_file() {
         fi
     else
         echo "[INFO] --cloud-config='${k8s_secret_vcp_configuration_file_location}'/vsphere.conf flag is already present in the manifest file: ${MANIFEST_FILE}"
+    fi
+
+    ## If VCP configuration file path is not mounted on the containers, mount the path, so that containers can read vsphere.conf file
+    volumepath=`jq '.spec.volumes' ${MANIFEST_FILE} | grep ${k8s_secret_vcp_configuration_file_location}`
+    if [ -z "$volumepath" ]; then
+        jq '.spec.volumes [.spec.volumes| length] |= . + { "hostPath": { "path": "'${k8s_secret_vcp_configuration_file_location}'" }, "name": "vsphereconf" }' ${MANIFEST_FILE} > ${MANIFEST_FILE}.tmp
+        if [ $? -eq 0 ]; then
+            mv ${MANIFEST_FILE}.tmp ${MANIFEST_FILE}
+            echo "[INFO] Suceessfully added volume: ${k8s_secret_vcp_configuration_file_location} in the manifest file: ${MANIFEST_FILE}"
+        else
+            ERROR_MSG="Failed to add volume: ${k8s_secret_vcp_configuration_file_location} in the manifest file: ${MANIFEST_FILE}"
+            update_VcpConigStatus "$POD_NAME" "$PHASE" "$DAEMONSET_PHASE_FAILED" "$ERROR_MSG"
+        fi
+    else
+        echo "[INFO] volume: ${k8s_secret_vcp_configuration_file_location} is already available in the manifest file: ${MANIFEST_FILE}"
+    fi
+
+    mountpath=`jq '.spec.containers[0].volumeMounts' ${MANIFEST_FILE} | grep ${k8s_secret_vcp_configuration_file_location}`
+    if [ -z "$mountpath" ]; then
+        jq '.spec.containers[0].volumeMounts[.spec.containers[0].volumeMounts| length] |= . + { "mountPath": "'${k8s_secret_vcp_configuration_file_location}'", "name": "vsphereconf", "readOnly": true }' ${MANIFEST_FILE} > ${MANIFEST_FILE}.tmp
+        if [ $? -eq 0 ]; then
+            mv ${MANIFEST_FILE}.tmp ${MANIFEST_FILE}
+            echo "[INFO] Suceessfully added mount path: ${k8s_secret_vcp_configuration_file_location} in the manifest file: ${MANIFEST_FILE}"
+        else
+            ERROR_MSG="Failed to add mount path: ${k8s_secret_vcp_configuration_file_location} in the manifest file: ${MANIFEST_FILE}"
+            update_VcpConigStatus "$POD_NAME" "$PHASE" "$DAEMONSET_PHASE_FAILED" "$ERROR_MSG"
+        fi
+    else
+        echo "[INFO] Path: ${k8s_secret_vcp_configuration_file_location} is already mounted in the manifest file: ${MANIFEST_FILE}"
     fi
 }
 
@@ -184,7 +220,7 @@ spec:
     status: "\"${INIT_STATUS}\""
     error: "\"${ERROR}\""" > /tmp/${POD_NAME}_daemonset_status_create.yaml
 
-    kubectl create --save-config -f /tmp/${POD_NAME}_daemonset_status_update.yaml
+    kubectl create --save-config -f /tmp/${POD_NAME}_daemonset_status_create.yaml
 }
 
 update_VcpConigStatus() {
@@ -205,7 +241,12 @@ spec:
     phase: "\"${PHASE}\""
     status: "\"${STATUS}\""
     error: "\"${ERROR}\""" > /tmp/${POD_NAME}_daemonset_status_update.yaml
-kubectl apply -f /tmp/${POD_NAME}_daemonset_status_update.yaml
+
+retry_attempt=1
+until kubectl apply -f /tmp/${POD_NAME}_daemonset_status_update.yaml &> /dev/null || [ $retry_attempt -eq 12 ]; do
+    sleep 5
+    $(( retry_attempt++ ))
+done
 }
 
 init_VcpConfigSummaryStatus() {
@@ -262,5 +303,10 @@ spec:
     nodes_sucessfully_configured : "\"${TOTAL_WITH_COMPLETE_STATUS}\""
     total_number_of_nodes: "\"${TOTAL_NUMBER_OF_NODES}\""" > /tmp/enablevcpstatussummary.yaml
 
-kubectl apply -f /tmp/enablevcpstatussummary.yaml
+retry_attempt=1
+until kubectl apply -f /tmp/enablevcpstatussummary.yaml &> /dev/null || [ $retry_attempt -eq 12 ]; do
+    sleep 5
+    $(( retry_attempt++ ))
+done
+
 }

--- a/enable-vcp-image/enable-vcp-scripts/daemonset_pod.sh
+++ b/enable-vcp-image/enable-vcp-scripts/daemonset_pod.sh
@@ -61,14 +61,15 @@ PHASE=$DAEMONSET_SCRIPT_PHASE4
 update_VcpConigStatus "$POD_NAME" "$PHASE" "$DAEMONSET_PHASE_RUNNING" ""
 
 # Creating back up directory for manifest files and kubelet service configuration file.
-ls /host/tmp/$POD_NAME &> /dev/null
+backupdir=$k8s_secret_config_backup/$POD_NAME
+ls $backupdir &> /dev/null
 if [ $? -ne 0 ]; then
-    echo "[INFO] Creating directory: '/host/tmp/$POD_NAME' for back up of manifest files and kubelet service configuration file"
-    mkdir /host/tmp/$POD_NAME
+    echo "[INFO] Creating directory: '${backupdir}' for back up of manifest files and kubelet service configuration file"
+    mkdir -p $backupdir
     if [ $? -eq 0 ]; then
-        echo "[INFO] Successfully created back up directory:" /host/tmp/$POD_NAME " on $NODE_NAME node"
+        echo "[INFO] Successfully created back up directory: ${backupdir} on ${NODE_NAME} node"
     else
-        ERROR_MSG="Failed to create directory: '/host/tmp/${POD_NAME}' for back up of manifest files and kubelet service configuration file"
+        ERROR_MSG="Failed to create directory: '${backupdir}' for back up of manifest files and kubelet service configuration file"
         update_VcpConigStatus "$POD_NAME" "$PHASE" "$DAEMONSET_PHASE_FAILED" "$ERROR_MSG"
         exit $ERROR_FAIL_TO_CREATE_BACKUP_DIRECTORY
     fi
@@ -79,7 +80,7 @@ ls /host/$k8s_secret_vcp_configuration_file_location &> /dev/null
 if [ $? -eq 0 ]; then
     echo "[INFO] Verified that the directory for the vSphere Cloud Provider configuration file is accessible. Path: ("/host/$k8s_secret_vcp_configuration_file_location ")"
 else
-    mkdir /host/$k8s_secret_vcp_configuration_file_location
+    mkdir -p /host/$k8s_secret_vcp_configuration_file_location
     if [ $? -ne 0 ]; then
         ERROR_MSG="Unable to Create Directory: /host/$k8s_secret_vcp_configuration_file_location for vSphere Conf file"
         update_VcpConigStatus "$POD_NAME" "$PHASE" "$DAEMONSET_PHASE_FAILED" "$ERROR_MSG"
@@ -111,7 +112,6 @@ if [ $? -ne 0 ]; then
 fi
 
 # locate and back up manifest files and kubelet service configuration file.
-backupdir=/host/tmp/$POD_NAME
 file=/host/$k8s_secret_kubernetes_api_server_manifest
 locate_validate_and_backup_files $file $backupdir $POD_NAME
 

--- a/enable-vcp-image/enable-vcp-scripts/daemonset_pod.sh
+++ b/enable-vcp-image/enable-vcp-scripts/daemonset_pod.sh
@@ -18,12 +18,6 @@ echo "Running script in the Pod:" $POD_NAME "deployed on the Node:" $NODE_NAME
 # read secret keys from volume /secret-volume/ and set values in an environment
 read_secret_keys
 
-if [ "$k8s_secret_master_node_name" == "$NODE_NAME" ]; then
-    echo "Daemonset pod is running on the master node"
-else
-    echo "Daemonset pod is running on the worker node"
-fi
-
 PHASE=$DAEMONSET_SCRIPT_PHASE2
 update_VcpConigStatus "$POD_NAME" "$PHASE" "$DAEMONSET_PHASE_RUNNING" ""
 
@@ -36,7 +30,7 @@ vmuuid=$(cat /host/sys/class/dmi/id/product_serial | sed -e 's/^VMware-//' -e 's
 ERROR_MSG="Unable to get VM UUID from /host/sys/class/dmi/id/product_serial"
 [ -z "$vmuuid" ] && { update_VcpConigStatus "$POD_NAME" "$PHASE" "$DAEMONSET_PHASE_FAILED" "$ERROR_MSG"; exit $ERROR_UNKNOWN; }
 
-vmpath=$(govc vm.info -vm.uuid=$vmuuid | grep "Path:" | awk 'BEGIN {FS=":"};{print $2}' | tr -d ' ')
+vmpath=$(govc vm.info -dc=$k8s_secret_datacenter -vm.uuid=$vmuuid | grep "Path:" | awk 'BEGIN {FS=":"};{print $2}' | tr -d ' ')
 ERROR_MSG="Unable to find VM using VM UUID: ${vmuuid}"
 [ -z "$vmpath" ] && { update_VcpConigStatus "$POD_NAME" "$PHASE" "$DAEMONSET_PHASE_FAILED" "$ERROR_MSG"; exit $ERROR_VC_OBJECT_NOT_FOUND; }
 
@@ -53,7 +47,7 @@ PHASE=$DAEMONSET_SCRIPT_PHASE3
 update_VcpConigStatus "$POD_NAME" "$PHASE" "$DAEMONSET_PHASE_RUNNING" ""
 
 # Move Node VM to the VM Folder.
-govc object.mv $vmpath $k8s_secret_node_vms_folder &> /dev/null
+govc object.mv -dc=$k8s_secret_datacenter $vmpath $k8s_secret_node_vms_folder &> /dev/null
 if [ $? -eq 0 ]; then
     echo "[INFO] Moved Node Virtual Machine to the Working Directory Folder".
 else
@@ -67,14 +61,17 @@ PHASE=$DAEMONSET_SCRIPT_PHASE4
 update_VcpConigStatus "$POD_NAME" "$PHASE" "$DAEMONSET_PHASE_RUNNING" ""
 
 # Creating back up directory for manifest files and kubelet service configuration file.
-echo "[INFO] Creating directory: '/host/tmp/$POD_NAME' for back up of manifest files and kubelet service configuration file"
-mkdir /host/tmp/$POD_NAME
-if [ $? -eq 0 ]; then
-    echo "[INFO] Successfully created back up directory:" /host/tmp/$POD_NAME " on $NODE_NAME node"
-else
-    ERROR_MSG="Failed to create directory: '/host/tmp/${POD_NAME}' for back up of manifest files and kubelet service configuration file"
-    update_VcpConigStatus "$POD_NAME" "$PHASE" "$DAEMONSET_PHASE_FAILED" "$ERROR_MSG"
-    exit $ERROR_FAIL_TO_CREATE_BACKUP_DIRECTORY
+ls /host/tmp/$POD_NAME &> /dev/null
+if [ $? -ne 0 ]; then
+    echo "[INFO] Creating directory: '/host/tmp/$POD_NAME' for back up of manifest files and kubelet service configuration file"
+    mkdir /host/tmp/$POD_NAME
+    if [ $? -eq 0 ]; then
+        echo "[INFO] Successfully created back up directory:" /host/tmp/$POD_NAME " on $NODE_NAME node"
+    else
+        ERROR_MSG="Failed to create directory: '/host/tmp/${POD_NAME}' for back up of manifest files and kubelet service configuration file"
+        update_VcpConigStatus "$POD_NAME" "$PHASE" "$DAEMONSET_PHASE_FAILED" "$ERROR_MSG"
+        exit $ERROR_FAIL_TO_CREATE_BACKUP_DIRECTORY
+    fi
 fi
 
 # Verify that the directory for the vSphere Cloud Provider configuration file is accessible.
@@ -82,27 +79,40 @@ ls /host/$k8s_secret_vcp_configuration_file_location &> /dev/null
 if [ $? -eq 0 ]; then
     echo "[INFO] Verified that the directory for the vSphere Cloud Provider configuration file is accessible. Path: ("/host/$k8s_secret_vcp_configuration_file_location ")"
 else
-    ERROR_MSG="Directory (/host/${k8s_secret_vcp_configuration_file_location}) for vSphere Cloud Provider Configuration file is not present"
-    update_VcpConigStatus "$POD_NAME" "$PHASE" "$DAEMONSET_PHASE_FAILED" "$ERROR_MSG"
-    exit $ERROR_VSPHERE_CONF_DIRECTORY_NOT_PRESENT
+    mkdir /host/$k8s_secret_vcp_configuration_file_location
+    if [ $? -ne 0 ]; then
+        ERROR_MSG="Unable to Create Directory: /host/$k8s_secret_vcp_configuration_file_location for vSphere Conf file"
+        update_VcpConigStatus "$POD_NAME" "$PHASE" "$DAEMONSET_PHASE_FAILED" "$ERROR_MSG"
+        exit $ERROR_VSPHERE_CONF_DIRECTORY_NOT_PRESENT
+    fi
+    chmod 0750 /host/$k8s_secret_vcp_configuration_file_location
+    ls /host/$k8s_secret_vcp_configuration_file_location &> /dev/null
+    if [ $? -ne 0 ]; then
+        ERROR_MSG="Directory (/host/${k8s_secret_vcp_configuration_file_location}) for vSphere Cloud Provider Configuration file is not present"
+        update_VcpConigStatus "$POD_NAME" "$PHASE" "$DAEMONSET_PHASE_FAILED" "$ERROR_MSG"
+        exit $ERROR_VSPHERE_CONF_DIRECTORY_NOT_PRESENT
+    fi
 fi
 
-ls /host/$k8s_secret_vcp_configuration_file_location/vsphere.conf &> /dev/null
-if [ $? -eq 0 ]; then
-    echo "[INFO] vsphere.conf file is already available at /host/$k8s_secret_vcp_configuration_file_location/vsphere.conf"
-    cp /host/$k8s_secret_vcp_configuration_file_location/vsphere.conf /host/tmp/$POD_NAME
+ls /host/tmp/$POD_NAME/vsphere.conf &> /dev/null
+if [ $? -ne 0 ]; then
+    ls /host/$k8s_secret_vcp_configuration_file_location/vsphere.conf &> /dev/null
     if [ $? -eq 0 ]; then
-        echo "[INFO] Existing vsphere.conf file is copied to" /host/tmp/$POD_NAME/vsphere.conf
-    else
-        ERROR_MSG="Failed to back up vsphere.conf file at " /host/tmp/${POD_NAME}/vsphere.conf
-        update_VcpConigStatus "$POD_NAME" "$PHASE" "$DAEMONSET_PHASE_FAILED" "$ERROR_MSG"
-        exit $ERROR_FAIL_TO_BACKUP_FILE
+        echo "[INFO] vsphere.conf file is already available at /host/$k8s_secret_vcp_configuration_file_location/vsphere.conf"
+        cp /host/$k8s_secret_vcp_configuration_file_location/vsphere.conf /host/tmp/$POD_NAME
+        if [ $? -eq 0 ]; then
+            echo "[INFO] Existing vsphere.conf file is copied to" /host/tmp/$POD_NAME/vsphere.conf
+        else
+            ERROR_MSG="Failed to back up vsphere.conf file at " /host/tmp/${POD_NAME}/vsphere.conf
+            update_VcpConigStatus "$POD_NAME" "$PHASE" "$DAEMONSET_PHASE_FAILED" "$ERROR_MSG"
+            exit $ERROR_FAIL_TO_BACKUP_FILE
+        fi
     fi
 fi
 
 # locate and back up manifest files and kubelet service configuration file.
-file=/host/$k8s_secret_kubernetes_api_server_manifest
 backupdir=/host/tmp/$POD_NAME
+file=/host/$k8s_secret_kubernetes_api_server_manifest
 locate_validate_and_backup_files $file $backupdir $POD_NAME
 
 file=/host/$k8s_secret_kubernetes_controller_manager_manifest
@@ -111,30 +121,33 @@ locate_validate_and_backup_files $file $backupdir $POD_NAME
 file=/host/$k8s_secret_kubernetes_kubelet_service_configuration_file
 locate_validate_and_backup_files $file $backupdir $POD_NAME
 
-
 PHASE=$DAEMONSET_SCRIPT_PHASE5
 update_VcpConigStatus "$POD_NAME" "$PHASE" "$DAEMONSET_PHASE_RUNNING" ""
 
 # Create vSphere Cloud Provider configuration file
-echo "[INFO] Creating vSphere Cloud Provider configuration file at /host/tmp/vsphere.conf"
-echo "[Global]
-    user = ""\"${k8s_secret_vcp_username}"\""
-    password = ""\"${k8s_secret_vcp_password}"\""
-    server = ""\"${k8s_secret_vc_ip}"\""
-    port = ""\"${k8s_secret_vc_port}"\""
-    insecure-flag = ""\"1"\""
-    datacenter = ""\"${k8s_secret_datacenter}"\""
-    datastore = ""\"${k8s_secret_default_datastore}"\""
-    working-dir = ""\"${k8s_secret_node_vms_folder}"\""
-[Disk]
-    scsicontrollertype = pvscsi" > /host/tmp/vsphere.conf
 
-if [ $? -eq 0 ]; then
-    echo "[INFO] successfully created vSphere.conf file at :" /host/tmp/vsphere.conf
-else
-    ERROR_MSG="Failed to create vsphere.conf file at : /host/tmp/vsphere.conf"
-    update_VcpConigStatus "$POD_NAME" "$PHASE" "FAILED" "$ERROR_MSG"
-    exit $ERROR_FAIL_TO_CREATE_FILE
+ls /host/tmp/vsphere.conf &> /dev/null
+if [ $? -ne 0 ]; then
+    echo "[INFO] Creating vSphere Cloud Provider configuration file at /host/tmp/vsphere.conf"
+    echo "[Global]
+        user = ""\"${k8s_secret_vcp_username}"\""
+        password = ""\"${k8s_secret_vcp_password}"\""
+        server = ""\"${k8s_secret_vc_ip}"\""
+        port = ""\"${k8s_secret_vc_port}"\""
+        insecure-flag = ""\"1"\""
+        datacenter = ""\"${k8s_secret_datacenter}"\""
+        datastore = ""\"${k8s_secret_default_datastore}"\""
+        working-dir = ""\"${k8s_secret_node_vms_folder}"\""
+    [Disk]
+        scsicontrollertype = pvscsi" > /host/tmp/vsphere.conf
+
+    if [ $? -eq 0 ]; then
+        echo "[INFO] successfully created vSphere.conf file at :" /host/tmp/vsphere.conf
+    else
+        ERROR_MSG="Failed to create vsphere.conf file at : /host/tmp/vsphere.conf"
+        update_VcpConigStatus "$POD_NAME" "$PHASE" "FAILED" "$ERROR_MSG"
+        exit $ERROR_FAIL_TO_CREATE_FILE
+    fi
 fi
 
 PHASE=$DAEMONSET_SCRIPT_PHASE6
@@ -221,12 +234,22 @@ if [ $? -eq 0 ]; then
     else
         ExecStart=$(echo $ExecStart "--cloud-provider=vsphere")
     fi
+    
     echo $ExecStart | grep "\-\-cloud-config=${k8s_secret_vcp_configuration_file_location}/vsphere.conf" &> /dev/null
     if [ $? -eq 0 ]; then
         echo "[INFO] cloud-config='${k8s_secret_vcp_configuration_file_location}'/vsphere.conf flag is already present in the kubelet service configuration"
     else
         ExecStart=$(echo $ExecStart "--cloud-config=${k8s_secret_vcp_configuration_file_location}/vsphere.conf")
     fi
+
+    echo $ExecStart | grep "${k8s_secret_vcp_configuration_file_location}:${k8s_secret_vcp_configuration_file_location}" &> /dev/null
+    if [ $? -eq 0 ]; then
+        echo "[INFO] Volume ${k8s_secret_vcp_configuration_file_location} is already present in the kubelet service configuration"
+    else
+        addvolumeoption="docker run -v ${k8s_secret_vcp_configuration_file_location}:${k8s_secret_vcp_configuration_file_location}"
+        ExecStart="${ExecStart/docker run/$addvolumeoption}"
+    fi
+
     echo ExecStart="$ExecStart" | crudini --merge /host/tmp/kubelet-service-configuration Service
     if [ $? -eq 0 ]; then 
         echo "[INFO] Sucessfully updated kubelet.service configuration"
@@ -265,9 +288,10 @@ fi
 PHASE=$DAEMONSET_SCRIPT_PHASE7
 update_VcpConigStatus "$POD_NAME" "$PHASE" "$DAEMONSET_PHASE_RUNNING" ""
 
-echo "systemctl daemon-reload
+echo '#!/bin/sh
+systemctl daemon-reload
 systemctl restart ${k8s_secret_kubernetes_kubelet_service_name}
-" > /host/tmp/restart_kubelet.sh
+' > /host/tmp/restart_kubelet.sh
 chmod +x /host/tmp/restart_kubelet.sh
 
 echo "[INFO] Reloading systemd manager configuration and restarting kubelet service"
@@ -280,3 +304,4 @@ else
     ERROR_MSG="Failed to restart kubelet service"
     update_VcpConigStatus "$POD_NAME" "$PHASE" "$DAEMONSET_PHASE_FAILED" "$ERROR_MSG"
 fi
+touch /host/tmp/vcp-configuration-complete

--- a/enable-vcp-image/enable-vcp-scripts/run.sh
+++ b/enable-vcp-image/enable-vcp-scripts/run.sh
@@ -11,10 +11,16 @@ if [ "$POD_ROLE" == "MANAGER" ]; then
     echo "Running Manager Role"
     /opt/enable-vcp-scripts/manager_pod.sh
 elif [ "$POD_ROLE" == "DAEMON" ]; then
+    ls /host/tmp/vcp-configuration-complete &> /dev/null
+    if [ $? -eq 0 ]; then
+        # Daemon Pod has already completed VCP Configuration, So Pause infinity
+        python -c 'while 1: import ctypes; ctypes.CDLL(None).pause()'
+    fi
     echo "Running Daemon Role"
-    /opt/enable-vcp-scripts/daemonset_pod.sh
+    bash /opt/enable-vcp-scripts/daemonset_pod.sh
 else
     echo "[ERROR] Invalid Role"; 
     exit $ERROR_INVALID_POD_ROLE;
 fi
-sleep infinity
+# sleep infinity
+python -c 'while 1: import ctypes; ctypes.CDLL(None).pause()'

--- a/enable-vcp-image/enable-vcp-scripts/vcp-daemontset.yaml
+++ b/enable-vcp-image/enable-vcp-scripts/vcp-daemontset.yaml
@@ -32,7 +32,7 @@ spec:
       serviceAccountName: vcpsa
       containers:
       - name: vcp-container
-        image: divyen/enablevcp:v1
+        image: cnastorage/enablevcp:v1
         env:
         - name: POD_ROLE
           value: "DAEMON"

--- a/enable-vcp-image/install.sh
+++ b/enable-vcp-image/install.sh
@@ -1,30 +1,19 @@
 #!/bin/bash
 #### ---- Install Package Dependencies ---- ####
-apt-get update && apt-get install -y curl git jq crudini
-rm -rf /var/lib/apt/lists/*
 
-export DEBIAN_FRONTEND="noninteractive"
-export GOVERSION="1.8.3"
-export GOROOT="/opt/go"
-export GOPATH="/root/.go"
-mkdir $GOPATH
+pip install crudini
+crudini --version
 
-cd /opt
-curl -LO https://storage.googleapis.com/golang/go${GOVERSION}.linux-amd64.tar.gz
-tar zxf go${GOVERSION}.linux-amd64.tar.gz && rm go${GOVERSION}.linux-amd64.tar.gz
-ln -s /opt/go/bin/go /usr/bin/
+go version
+go get -u github.com/vmware/govmomi/govc
 
-
-curl -L https://github.com/vmware/govmomi/releases/download/v0.15.0/govc_linux_amd64.gz | gunzip > /usr/local/bin/govc
-chmod +x /usr/local/bin/govc
-govc version
-
-curl -L https://github.com/y13i/j2y/releases/download/v0.0.8/j2y-linux_amd64.zip | gunzip > /usr/bin/j2y
-chmod +x /usr/bin/j2y
+cd /root
+wget  https://github.com/y13i/j2y/releases/download/v0.0.8/j2y-linux_amd64.zip
+unzip  j2y-linux_amd64.zip
+chmod +x ./j2y
+mv ./j2y /usr/local/bin/j2y
 j2y --version
 
-cd /opt
-curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
+wget https://storage.googleapis.com/kubernetes-release/release/v1.7.4/bin/linux/amd64/kubectl
 chmod +x ./kubectl
 mv ./kubectl /usr/local/bin/kubectl
-

--- a/enable-vsphere-cloud-provider.yaml
+++ b/enable-vsphere-cloud-provider.yaml
@@ -13,18 +13,20 @@ metadata:
 type: Opaque
 data:
   # base64 encode username and password
-  # echo -n 'username' | base64
-  # echo -n 'password' | base64
+  # vc_admin_username ==> echo -n 'Administrator@vsphere.local' | base64
+  # vc_admin_password ==> echo -n 'Admin!23' | base64
+  # vcp_username ==> echo -n 'vcpuser@vsphere.local' | base64
+  # vcp_password ==> echo -n 'Admin!23' | base64
+  #
   vc_admin_username: QWRtaW5pc3RyYXRvckB2c3BoZXJlLmxvY2Fs
   vc_admin_password: QWRtaW4hMjM=
   vcp_username: dmNwdXNlckB2c3BoZXJlLmxvY2Fs
   vcp_password: QWRtaW4hMjM=
 stringData:
-  master_node_name: "master"
-  vc_ip: "10.162.26.135"
+  vc_ip: "10.162.12.94"
   vc_port: "443"
   # datacenter is the datacenter name in which Node VMs are located.
-  datacenter: vcqaDC
+  datacenter: cna-storage-dc
   # default_datastore is the Default datastore VCP will use for provisioning volumes using storage classes/dynamic provisioning
   default_datastore: "vsanDatastore"
   # node_vms_folder is the name of VM folder where all node VMs are located or to be placed under vcp_datacenter. This folder will be created if not present.
@@ -33,7 +35,8 @@ stringData:
   node_vms_cluster_or_host : "cluster-vsan-1"
   
   # vcp_configuration_file_location is the location where the VCP configuration file will be created.
-  vcp_configuration_file_location: "/etc/kubernetes"
+  # This location should be mounted and accessible to controller pod, api server pod and kubelet pod.
+  vcp_configuration_file_location: "/etc/vsphereconf"
  
   # kubernetes_api_server_manifest is the file from which api server pod takes parameters
   kubernetes_api_server_manifest: "/etc/kubernetes/manifests/kube-apiserver.json"
@@ -58,7 +61,7 @@ metadata:
 spec:
     containers:
     - name: vcp-manager-container
-      image: divyen/enablevcp:v1
+      image: cnastorage/enablevcp:v1
       env:
       - name: POD_ROLE
         value: "MANAGER"

--- a/enable-vsphere-cloud-provider.yaml
+++ b/enable-vsphere-cloud-provider.yaml
@@ -37,7 +37,7 @@ stringData:
   # vcp_configuration_file_location is the location where the VCP configuration file will be created.
   # This location should be mounted and accessible to controller pod, api server pod and kubelet pod.
   vcp_configuration_file_location: "/etc/vsphereconf"
- 
+
   # kubernetes_api_server_manifest is the file from which api server pod takes parameters
   kubernetes_api_server_manifest: "/etc/kubernetes/manifests/kube-apiserver.json"
   # kubernetes_controller_manager_manifest is the file from which controller manager pod takes parameters
@@ -46,6 +46,8 @@ stringData:
   kubernetes_kubelet_service_name: kubelet.service
   # kubernetes_kubelet_service_configuration_file is the file from which kubelet reads parameters
   kubernetes_kubelet_service_configuration_file: "/etc/systemd/system/kubelet.service"
+
+  configuration_backup_directory: "/configurationbackup"
 ---
 apiVersion: v1
 kind: ServiceAccount


### PR DESCRIPTION
Issue: https://github.com/vmware/kubernetes/issues/215

Observed following issues during testing and fixed as part of this PR.

- Handled case when user specifies new folder path for vsphere.conf file instead of /etc/kubernetes, we need to make sure this new path is mounted to API server, controller and kubelet pods.

- Image size was very large due to Ubuntu 16.10 was used as the base container image, changed it to gliderlabs/alpine

- Handled daemonset restart case. When daemonset is finished with all of its task, created a flag file at /host/tmp/vcp-configuration-complete. if daemonset is restarted and it detect this file, it will just pause infinity, as all of the tasks are already completed. If not present re-configuration will be performed.

- Modified Daemonset script to make it safe for re-execution from middle, if all tasks are not finished.

- Added retry logic for updating TPR from daemonset, in case when kubelet is being restarted on the master node, and daemonset tries to update TPR, request was failing due to API server not available. Verified re-try logic is correctly reporting the status.

- Created and published new image at - cnastorage/enablevcp:v1

- Fixed code with to only skip Role Creation and Privileges assignment when user specified same username for admin and VCP user.


Please review: @BaluDontu @rohitjogvmw @tusharnt @SandeepPissay @luomiao 