### PR TITLE
E2E test for statefulsets for vsphere cloud provider

### DIFF
--- a/test/e2e/storage/BUILD
+++ b/test/e2e/storage/BUILD
@@ -23,6 +23,7 @@ go_library(
         "volume_metrics.go",
         "volume_provisioning.go",
         "volumes.go",
+        "vsphere_statefulsets.go",
         "vsphere_utils.go",
         "vsphere_volume_diskformat.go",
         "vsphere_volume_fstype.go",

--- a/test/e2e/storage/vsphere_statefulsets.go
+++ b/test/e2e/storage/vsphere_statefulsets.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storage
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/test/e2e/framework"
+)
+
+const (
+	manifestPath     = "test/e2e/testing-manifests/statefulset/nginx"
+	mountPath        = "/usr/share/nginx/html"
+	storageclassname = "nginx-sc"
+)
+
+var _ = SIGDescribe("vsphere statefulsets", func() {
+	f := framework.NewDefaultFramework("vsphere-statefulsets")
+	var (
+		namespace string
+		client    clientset.Interface
+	)
+	BeforeEach(func() {
+		framework.SkipUnlessProviderIs("vsphere")
+		namespace = f.Namespace.Name
+		client = f.ClientSet
+	})
+	AfterEach(func() {
+		framework.Logf("Deleting all statefulset in namespace: %v", namespace)
+		framework.DeleteAllStatefulSets(client, namespace)
+	})
+
+	It("vsphere statefulsets testing", func() {
+		By("Creating StorageClass for Statefulsets")
+		scParameters := make(map[string]string)
+		scParameters["diskformat"] = "thin"
+		scSpec := getVSphereStorageClassSpec(storageclassname, scParameters)
+		sc, err := client.StorageV1().StorageClasses().Create(scSpec)
+		Expect(err).NotTo(HaveOccurred())
+		defer client.StorageV1().StorageClasses().Delete(sc.Name, nil)
+
+		By("Creating statefulsets with number of Replica :4")
+		statefulsetsTester := framework.NewStatefulSetTester(client)
+		statefulsets := statefulsetsTester.CreateStatefulSet(manifestPath, namespace)
+		statefulsetsTester.CheckMount(statefulsets, mountPath)
+
+		By("Scaling down statefulsets to number of Replica: 2")
+		statefulsetsTester.Scale(statefulsets, 2)
+		statefulsetsTester.WaitForStatusReplicas(statefulsets, 2)
+
+		By("Scaling up statefulsets to number of Replica: 5")
+		statefulsetsTester.Scale(statefulsets, 5)
+		statefulsetsTester.WaitForStatusReplicas(statefulsets, 5)
+	})
+})

--- a/test/e2e/testing-manifests/statefulset/nginx/service.yaml
+++ b/test/e2e/testing-manifests/statefulset/nginx/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx
+  labels:
+    app: nginx
+spec:
+  ports:
+  - port: 80
+    name: web
+  clusterIP: None
+  selector:
+    app: nginx

--- a/test/e2e/testing-manifests/statefulset/nginx/statefulset.yaml
+++ b/test/e2e/testing-manifests/statefulset/nginx/statefulset.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1beta1
+kind: StatefulSet
+metadata:
+  name: web
+spec:
+  serviceName: "nginx"
+  replicas: 4
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: gcr.io/google_containers/nginx-slim:0.8
+        ports:
+        - containerPort: 80
+          name: web
+        volumeMounts:
+        - name: www
+          mountPath: /usr/share/nginx/html
+  volumeClaimTemplates:
+  - metadata:
+      name: www
+      annotations:
+        volume.beta.kubernetes.io/storage-class: nginx-sc
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: 1Gi


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a new e2e test for statefulsets for vSphere cloud Provider.

Test does following tasks.
- Create a storage class with thin diskformat.
- Create nginx service.
- Create nginx statefulsets with 4 replicas.
- Wait until all Pods are ready and PVCs are bounded with PV.
- Verify volumes are accessible in all statefulsets pods with creating empty file.
- scale down statefulsets to 2 replicas.
- scale up statefulsets to 5 replicas.
- scale down statefulsets to 0 replicas and delete all pods.
- delete all PVCs from the test namespace.
- delete the storage class.


Issue: https://github.com/vmware/kubernetes/issues/275

**Special notes for your reviewer**:
Test Logs
```
$ go run hack/e2e.go --check-version-skew=false -v -test --test_args='--ginkgo.focus=vsphere\sstatefulsets\stesting'
flag provided but not defined: -check-version-skew
Usage of /var/folders/_c/jphrps7d6x5_v7s81fv3k0wr002gzv/T/go-build556049984/command-line-arguments/_obj/exe/e2e:
  -get
    	go get -u kubetest if old or not installed (default true)
  -old duration
    	Consider kubetest old if it exceeds this (default 24h0m0s)
2017/09/27 14:32:26 e2e.go:55: NOTICE: go run hack/e2e.go is now a shim for test-infra/kubetest
2017/09/27 14:32:26 e2e.go:56:   Usage: go run hack/e2e.go [--get=true] [--old=24h0m0s] -- [KUBETEST_ARGS]
2017/09/27 14:32:26 e2e.go:57:   The separator is required to use --get or --old flags
2017/09/27 14:32:26 e2e.go:58:   The -- flag separator also suppresses this message
2017/09/27 14:32:26 e2e.go:77: Calling kubetest --check-version-skew=false -v -test --test_args=--ginkgo.focus=vsphere\sstatefulsets\stesting...
2017/09/27 14:32:26 util.go:154: Running: ./cluster/kubectl.sh --match-server-version=false version
2017/09/27 14:32:26 util.go:156: Step './cluster/kubectl.sh --match-server-version=false version' finished in 195.970283ms
2017/09/27 14:32:26 util.go:154: Running: ./hack/e2e-internal/e2e-status.sh
Skeleton Provider: prepare-e2e not implemented
Client Version: version.Info{Major:"1", Minor:"6+", GitVersion:"v1.6.0-alpha.0.16650+b188868fd92959-dirty", GitCommit:"b188868fd929593a0fcf41a7ee2afe3e10b03c39", GitTreeState:"dirty", BuildDate:"2017-09-27T21:16:49Z", GoVersion:"go1.8.3", Compiler:"gc", Platform:"darwin/amd64"}
Server Version: version.Info{Major:"1", Minor:"9+", GitVersion:"v1.9.0-alpha.1.358+5a721f5a02368d", GitCommit:"5a721f5a02368df6276dee0ef9595fbcc984a6bd", GitTreeState:"clean", BuildDate:"2017-09-27T07:42:40Z", GoVersion:"go1.8.3", Compiler:"gc", Platform:"linux/amd64"}
2017/09/27 14:32:26 util.go:156: Step './hack/e2e-internal/e2e-status.sh' finished in 120.374624ms
2017/09/27 14:32:26 util.go:154: Running: ./hack/ginkgo-e2e.sh --ginkgo.focus=vsphere\sstatefulsets\stesting
Conformance test: not doing test setup.
Sep 27 14:32:27.288: INFO: Overriding default scale value of zero to 1
Sep 27 14:32:27.288: INFO: Overriding default milliseconds value of zero to 5000
I0927 14:32:27.392808   79577 e2e.go:369] Starting e2e run "5bcb10e4-a3cb-11e7-a06c-a45e60f0ef8b" on Ginkgo node 1
Running Suite: Kubernetes e2e suite
===================================
Random Seed: 1506547946 - Will randomize all specs
Will run 1 of 695 specs

Sep 27 14:32:27.407: INFO: >>> kubeConfig: /Users/divyenp/.kube/config
Sep 27 14:32:27.415: INFO: Waiting up to 4h0m0s for all (but 0) nodes to be schedulable
Sep 27 14:32:27.443: INFO: Waiting up to 10m0s for all pods (need at least 0) in namespace 'kube-system' to be running and ready
Sep 27 14:32:27.503: INFO: 13 / 13 pods in namespace 'kube-system' are running and ready (0 seconds elapsed)
Sep 27 14:32:27.503: INFO: expected 4 pod replicas in namespace 'kube-system', 4 are Running and Ready.
Sep 27 14:32:27.507: INFO: Waiting for pods to enter Success, but no pods in "kube-system" match label map[name:e2e-image-puller]
Sep 27 14:32:27.507: INFO: Dumping network health container logs from all nodes...
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
------------------------------
[sig-storage] vsphere statefulsets 
  vsphere statefulsets testing
  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/storage/vsphere_statefulsets.go:70
[BeforeEach] [sig-storage] vsphere statefulsets
  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
STEP: Creating a kubernetes client
Sep 27 14:32:27.515: INFO: >>> kubeConfig: /Users/divyenp/.kube/config
STEP: Building a namespace api object
STEP: Waiting for a default service account to be provisioned in namespace
[BeforeEach] [sig-storage] vsphere statefulsets
  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/storage/vsphere_statefulsets.go:43
[It] vsphere statefulsets testing
  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/storage/vsphere_statefulsets.go:70
STEP: Creating StorageClass for Statefulsets
STEP: Creating nginx statefulsets With number of Replica :4
Sep 27 14:32:27.593: INFO: Parsing statefulset from test/e2e/testing-manifests/statefulset/nginx/statefulset.yaml
Sep 27 14:32:27.602: INFO: Parsing service from test/e2e/testing-manifests/statefulset/nginx/service.yaml
Sep 27 14:32:27.606: INFO: creating web service
Sep 27 14:32:27.612: INFO: creating statefulset e2e-tests-vsphere-statefulsets-hl5cd/web with 4 replicas and selector &LabelSelector{MatchLabels:map[string]string{app: nginx,},MatchExpressions:[],}
Sep 27 14:32:27.642: INFO: Found 0 stateful pods, waiting for 4
Sep 27 14:32:37.649: INFO: Found 1 stateful pods, waiting for 4
Sep 27 14:32:47.647: INFO: Found 2 stateful pods, waiting for 4
Sep 27 14:32:57.649: INFO: Found 3 stateful pods, waiting for 4
Sep 27 14:33:07.647: INFO: Found 3 stateful pods, waiting for 4
Sep 27 14:33:17.648: INFO: Found 3 stateful pods, waiting for 4
Sep 27 14:33:27.648: INFO: Waiting for pod web-0 to enter Running - Ready=true, currently Running - Ready=true
Sep 27 14:33:27.648: INFO: Waiting for pod web-1 to enter Running - Ready=true, currently Running - Ready=true
Sep 27 14:33:27.648: INFO: Waiting for pod web-2 to enter Running - Ready=true, currently Running - Ready=true
Sep 27 14:33:27.648: INFO: Waiting for pod web-3 to enter Running - Ready=true, currently Pending - Ready=false
Sep 27 14:33:37.649: INFO: Waiting for pod web-0 to enter Running - Ready=true, currently Running - Ready=true
Sep 27 14:33:37.649: INFO: Waiting for pod web-1 to enter Running - Ready=true, currently Running - Ready=true
Sep 27 14:33:37.649: INFO: Waiting for pod web-2 to enter Running - Ready=true, currently Running - Ready=true
Sep 27 14:33:37.650: INFO: Waiting for pod web-3 to enter Running - Ready=true, currently Pending - Ready=false
Sep 27 14:33:47.647: INFO: Waiting for pod web-0 to enter Running - Ready=true, currently Running - Ready=true
Sep 27 14:33:47.647: INFO: Waiting for pod web-1 to enter Running - Ready=true, currently Running - Ready=true
Sep 27 14:33:47.647: INFO: Waiting for pod web-2 to enter Running - Ready=true, currently Running - Ready=true
Sep 27 14:33:47.647: INFO: Waiting for pod web-3 to enter Running - Ready=true, currently Running - Ready=true
Sep 27 14:33:47.653: INFO: Running '/Users/divyenp/github/vmware/kubernetes/_output/dockerized/bin/darwin/amd64/kubectl --server=https://10.192.54.86 --kubeconfig=/Users/divyenp/.kube/config exec --namespace=e2e-tests-vsphere-statefulsets-hl5cd web-0 -- /bin/sh -c ls -idlh /usr/share/nginx/html'
Sep 27 14:33:48.003: INFO: stderr: ""
Sep 27 14:33:48.003: INFO: stdout of ls -idlh /usr/share/nginx/html on web-0: 2 drwxr-xr-x 3 root root 4.0K Sep 27 21:31 /usr/share/nginx/html

Sep 27 14:33:48.003: INFO: Running '/Users/divyenp/github/vmware/kubernetes/_output/dockerized/bin/darwin/amd64/kubectl --server=https://10.192.54.86 --kubeconfig=/Users/divyenp/.kube/config exec --namespace=e2e-tests-vsphere-statefulsets-hl5cd web-1 -- /bin/sh -c ls -idlh /usr/share/nginx/html'
Sep 27 14:33:48.254: INFO: stderr: ""
Sep 27 14:33:48.254: INFO: stdout of ls -idlh /usr/share/nginx/html on web-1: 2 drwxr-xr-x 3 root root 4.0K Sep 27 21:31 /usr/share/nginx/html

Sep 27 14:33:48.255: INFO: Running '/Users/divyenp/github/vmware/kubernetes/_output/dockerized/bin/darwin/amd64/kubectl --server=https://10.192.54.86 --kubeconfig=/Users/divyenp/.kube/config exec --namespace=e2e-tests-vsphere-statefulsets-hl5cd web-2 -- /bin/sh -c ls -idlh /usr/share/nginx/html'
Sep 27 14:33:48.506: INFO: stderr: ""
Sep 27 14:33:48.506: INFO: stdout of ls -idlh /usr/share/nginx/html on web-2: 2 drwxr-xr-x 3 root root 4.0K Sep 27 21:32 /usr/share/nginx/html

Sep 27 14:33:48.506: INFO: Running '/Users/divyenp/github/vmware/kubernetes/_output/dockerized/bin/darwin/amd64/kubectl --server=https://10.192.54.86 --kubeconfig=/Users/divyenp/.kube/config exec --namespace=e2e-tests-vsphere-statefulsets-hl5cd web-3 -- /bin/sh -c ls -idlh /usr/share/nginx/html'
Sep 27 14:33:48.771: INFO: stderr: ""
Sep 27 14:33:48.771: INFO: stdout of ls -idlh /usr/share/nginx/html on web-3: 2 drwxr-xr-x 3 root root 4.0K Sep 27 21:32 /usr/share/nginx/html

Sep 27 14:33:48.777: INFO: Running '/Users/divyenp/github/vmware/kubernetes/_output/dockerized/bin/darwin/amd64/kubectl --server=https://10.192.54.86 --kubeconfig=/Users/divyenp/.kube/config exec --namespace=e2e-tests-vsphere-statefulsets-hl5cd web-0 -- /bin/sh -c find /usr/share/nginx/html'
Sep 27 14:33:49.010: INFO: stderr: ""
Sep 27 14:33:49.010: INFO: stdout of find /usr/share/nginx/html on web-0: /usr/share/nginx/html
/usr/share/nginx/html/lost+found

Sep 27 14:33:49.010: INFO: Running '/Users/divyenp/github/vmware/kubernetes/_output/dockerized/bin/darwin/amd64/kubectl --server=https://10.192.54.86 --kubeconfig=/Users/divyenp/.kube/config exec --namespace=e2e-tests-vsphere-statefulsets-hl5cd web-1 -- /bin/sh -c find /usr/share/nginx/html'
Sep 27 14:33:49.222: INFO: stderr: ""
Sep 27 14:33:49.222: INFO: stdout of find /usr/share/nginx/html on web-1: /usr/share/nginx/html
/usr/share/nginx/html/lost+found

Sep 27 14:33:49.222: INFO: Running '/Users/divyenp/github/vmware/kubernetes/_output/dockerized/bin/darwin/amd64/kubectl --server=https://10.192.54.86 --kubeconfig=/Users/divyenp/.kube/config exec --namespace=e2e-tests-vsphere-statefulsets-hl5cd web-2 -- /bin/sh -c find /usr/share/nginx/html'
Sep 27 14:33:49.444: INFO: stderr: ""
Sep 27 14:33:49.444: INFO: stdout of find /usr/share/nginx/html on web-2: /usr/share/nginx/html
/usr/share/nginx/html/lost+found

Sep 27 14:33:49.444: INFO: Running '/Users/divyenp/github/vmware/kubernetes/_output/dockerized/bin/darwin/amd64/kubectl --server=https://10.192.54.86 --kubeconfig=/Users/divyenp/.kube/config exec --namespace=e2e-tests-vsphere-statefulsets-hl5cd web-3 -- /bin/sh -c find /usr/share/nginx/html'
Sep 27 14:33:49.803: INFO: stderr: ""
Sep 27 14:33:49.803: INFO: stdout of find /usr/share/nginx/html on web-3: /usr/share/nginx/html
/usr/share/nginx/html/lost+found

Sep 27 14:33:49.811: INFO: Running '/Users/divyenp/github/vmware/kubernetes/_output/dockerized/bin/darwin/amd64/kubectl --server=https://10.192.54.86 --kubeconfig=/Users/divyenp/.kube/config exec --namespace=e2e-tests-vsphere-statefulsets-hl5cd web-0 -- /bin/sh -c touch /usr/share/nginx/html/1506548027649555639'
Sep 27 14:33:50.038: INFO: stderr: ""
Sep 27 14:33:50.038: INFO: stdout of touch /usr/share/nginx/html/1506548027649555639 on web-0: 
Sep 27 14:33:50.038: INFO: Running '/Users/divyenp/github/vmware/kubernetes/_output/dockerized/bin/darwin/amd64/kubectl --server=https://10.192.54.86 --kubeconfig=/Users/divyenp/.kube/config exec --namespace=e2e-tests-vsphere-statefulsets-hl5cd web-1 -- /bin/sh -c touch /usr/share/nginx/html/1506548027649555639'
Sep 27 14:33:50.260: INFO: stderr: ""
Sep 27 14:33:50.260: INFO: stdout of touch /usr/share/nginx/html/1506548027649555639 on web-1: 
Sep 27 14:33:50.260: INFO: Running '/Users/divyenp/github/vmware/kubernetes/_output/dockerized/bin/darwin/amd64/kubectl --server=https://10.192.54.86 --kubeconfig=/Users/divyenp/.kube/config exec --namespace=e2e-tests-vsphere-statefulsets-hl5cd web-2 -- /bin/sh -c touch /usr/share/nginx/html/1506548027649555639'
Sep 27 14:33:50.463: INFO: stderr: ""
Sep 27 14:33:50.463: INFO: stdout of touch /usr/share/nginx/html/1506548027649555639 on web-2: 
Sep 27 14:33:50.463: INFO: Running '/Users/divyenp/github/vmware/kubernetes/_output/dockerized/bin/darwin/amd64/kubectl --server=https://10.192.54.86 --kubeconfig=/Users/divyenp/.kube/config exec --namespace=e2e-tests-vsphere-statefulsets-hl5cd web-3 -- /bin/sh -c touch /usr/share/nginx/html/1506548027649555639'
Sep 27 14:33:50.695: INFO: stderr: ""
Sep 27 14:33:50.695: INFO: stdout of touch /usr/share/nginx/html/1506548027649555639 on web-3: 
STEP: Scaling down nginx statefulsets to number of Replica: 2
Sep 27 14:33:50.695: INFO: Scaling statefulset web to 2
Sep 27 14:34:40.725: INFO: Waiting for statefulset status.replicas updated to 2
STEP: Scaling up nginx statefulsets to number of Replica: 5
Sep 27 14:34:40.729: INFO: Scaling statefulset web to 5
Sep 27 14:35:10.750: INFO: Waiting for statefulset status.replicas updated to 5
[AfterEach] [sig-storage] vsphere statefulsets
  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
Sep 27 14:35:10.760: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
STEP: Destroying namespace "e2e-tests-vsphere-statefulsets-hl5cd" for this suite.
Sep 27 14:36:12.908: INFO: namespace: e2e-tests-vsphere-statefulsets-hl5cd, resource: bindings, ignored listing per whitelist
Sep 27 14:36:12.985: INFO: namespace e2e-tests-vsphere-statefulsets-hl5cd deletion completed in 1m2.218726616s
[AfterEach] [sig-storage] vsphere statefulsets
  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/storage/vsphere_statefulsets.go:47
Sep 27 14:36:12.986: INFO: Deleting all statefulset in namespace: e2e-tests-vsphere-statefulsets-hl5cd

• [SLOW TEST:225.483 seconds]
[sig-storage] vsphere statefulsets
/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/storage/framework.go:22
  vsphere statefulsets testing
  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/storage/vsphere_statefulsets.go:70
------------------------------
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSep 27 14:36:13.001: INFO: Running AfterSuite actions on all node
Sep 27 14:36:13.001: INFO: Running AfterSuite actions on node 1

Ran 1 of 695 Specs in 225.594 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 694 Skipped PASS

Ginkgo ran 1 suite in 3m46.062459002s
Test Suite Passed
2017/09/27 14:36:13 util.go:156: Step './hack/ginkgo-e2e.sh --ginkgo.focus=vsphere\sstatefulsets\stesting' finished in 3m46.445969892s
2017/09/27 14:36:13 e2e.go:81: Done
```

Please review: @BaluDontu  @SandeepPissay @rohitjogvmw
