### PR TITLE
Part-1 - VCP Stress Test

### DIFF
--- a/test/e2e/storage/BUILD
+++ b/test/e2e/storage/BUILD
@@ -23,6 +23,7 @@ go_library(
         "volume_metrics.go",
         "volume_provisioning.go",
         "volumes.go",
+        "vsphere_stress.go",
         "vsphere_utils.go",
         "vsphere_volume_diskformat.go",
         "vsphere_volume_fstype.go",

--- a/test/e2e/storage/vsphere_stress.go
+++ b/test/e2e/storage/vsphere_stress.go
@@ -1,0 +1,126 @@
+package storage
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/api/core/v1"
+	storageV1 "k8s.io/api/storage/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/test/e2e/framework"
+	"os"
+	"strconv"
+	"sync"
+)
+
+/*
+	Induce stress to create volumes in parallel with multiple threads based on user configurable values for number of volumes and threads.
+	The following actions will be performed as part of this test.
+
+	1. Create Storage Classes of 4 Categories (Default, SC with Non Default Datastore, SC with SPBM Policy, SC with VSAN Storage Capalibilies.)
+    2. READ VCP_STRESS_INSTANCES and VCP_STRESS_VOLUMES_PER_INSTANCE from System Environment.
+	3. Launch goroutine for creating volumes n times. Here n is the value specified by the user in the system env VCP_STRESS_INSTANCES env variable.
+	4. Each instance of routine creates m number of volumes using the storage classes created in step-1. Here m is value specified by the user in the system env VCP_STRESS_VOLUMES_PER_INSTANCE.
+*/
+var _ = SIGDescribe("vcp-stress", func() {
+	f := framework.NewDefaultFramework("vcp-stress")
+	var (
+		client    clientset.Interface
+		namespace string
+	)
+
+	BeforeEach(func() {
+		framework.SkipUnlessProviderIs("vsphere")
+		client = f.ClientSet
+		namespace = f.Namespace.Name
+		Expect(os.Getenv("VCP_STRESS_INSTANCES")).NotTo(BeEmpty(), "ENV VCP_STRESS_INSTANCES is not set")
+		Expect(os.Getenv("VCP_STRESS_VOLUMES_PER_INSTANCE")).NotTo(BeEmpty(), "ENV VCP_STRESS_VOLUMES_PER_INSTANCE is not set")
+		Expect(os.Getenv("VSPHERE_SPBM_GOLD_POLICY")).NotTo(BeEmpty(), "ENV VSPHERE_SPBM_GOLD_POLICY is not set")
+		Expect(os.Getenv("VSPHERE_DATASTORE")).NotTo(BeEmpty(), "ENV VSPHERE_DATASTORE is not set")
+	})
+
+	It("vsphere stress tests", func() {
+
+		// if VCP_STRESS_INSTANCES = 10 and VCP_STRESS_VOLUMES_PER_INSTANCE is 20, 200 Volumes Will Created.
+		// Volumes will be provisioned with each different types of Storage Class, in this case 50 volumes per SC.
+
+		scArrays := make([]*storageV1.StorageClass, 4)
+		// Create default vSphere Storage Class
+		By("Creating Storage Class : sc-default")
+		scDefaultSpec := getVSphereStorageClassSpec("sc-default", nil)
+		scDefault, err := client.StorageV1().StorageClasses().Create(scDefaultSpec)
+		Expect(err).NotTo(HaveOccurred())
+		defer client.StorageV1().StorageClasses().Delete(scDefault.Name, nil)
+		scArrays[0] = scDefault
+
+		// Create Storage Class with vSan Parameters
+		By("Creating Storage Class : sc-vsan")
+		var scVSanParameters map[string]string
+		scVSanParameters = make(map[string]string)
+		scVSanParameters[Policy_HostFailuresToTolerate] = "1"
+		scVSanSpec := getVSphereStorageClassSpec("sc-vsan", scVSanParameters)
+		scVSan, err := client.StorageV1().StorageClasses().Create(scVSanSpec)
+		Expect(err).NotTo(HaveOccurred())
+		defer client.StorageV1().StorageClasses().Delete(scVSan.Name, nil)
+		scArrays[1] = scVSan
+
+		// Create Storage Class with SPBM Policy
+		By("Creating Storage Class : sc-spbm")
+		var scSPBMPolicyParameters map[string]string
+		scSPBMPolicyParameters = make(map[string]string)
+		goldPolicy := os.Getenv("VSPHERE_SPBM_GOLD_POLICY")
+		Expect(goldPolicy).NotTo(BeEmpty())
+		scSPBMPolicyParameters[SpbmStoragePolicy] = goldPolicy
+		scSPBMPolicySpec := getVSphereStorageClassSpec("sc-spbm", scSPBMPolicyParameters)
+		scSPBMPolicy, err := client.StorageV1().StorageClasses().Create(scSPBMPolicySpec)
+		Expect(err).NotTo(HaveOccurred())
+		defer client.StorageV1().StorageClasses().Delete(scSPBMPolicy.Name, nil)
+		scArrays[2] = scSPBMPolicy
+
+		// Create Storage Class with User Specified Datastore.
+		By("Creating Storage Class : sc-user-specified-ds")
+		var scWithDSParameters map[string]string
+		scWithDSParameters = make(map[string]string)
+		datastore := os.Getenv("VSPHERE_DATASTORE")
+		Expect(goldPolicy).NotTo(BeEmpty())
+		scWithDSParameters[Datastore] = datastore
+		scWithDatastoreSpec := getVSphereStorageClassSpec("sc-user-specified-ds", scWithDSParameters)
+		scWithDatastore, err := client.StorageV1().StorageClasses().Create(scWithDatastoreSpec)
+		Expect(err).NotTo(HaveOccurred())
+		defer client.StorageV1().StorageClasses().Delete(scWithDatastore.Name, nil)
+		scArrays[3] = scWithDatastore
+
+		instances, err := strconv.Atoi(os.Getenv("VCP_STRESS_INSTANCES"))
+		Expect(err).NotTo(HaveOccurred(), "Error Parsing VCP-STRESS-INSTANCES")
+
+		volumesPerInstance, err := strconv.Atoi(os.Getenv("VCP_STRESS_VOLUMES_PER_INSTANCE"))
+		Expect(err).NotTo(HaveOccurred(), "Error Parsing VCP_STRESS_VOLUMES_PER_INSTANCE")
+
+		var wg sync.WaitGroup
+		wg.Add(instances)
+		for instanceCount := 0; instanceCount < instances; instanceCount++ {
+			go CreateVolumesInParallel(client, namespace, scArrays, volumesPerInstance, &wg)
+		}
+		wg.Wait()
+	})
+
+})
+
+func CreateVolumesInParallel(client clientset.Interface, namespace string, sc []*storageV1.StorageClass, volumesPerInstance int, wg *sync.WaitGroup) {
+	defer wg.Done()
+	pvclaims := make([]*v1.PersistentVolumeClaim, volumesPerInstance)
+	for index := 0; index < volumesPerInstance; index++ {
+		By("Creating PVC using the Storage Class")
+		pvclaimSpec := getVSphereClaimSpecWithStorageClassAnnotation(namespace, sc[index%len(sc)])
+		pvclaim, err := client.CoreV1().PersistentVolumeClaims(namespace).Create(pvclaimSpec)
+		Expect(err).NotTo(HaveOccurred())
+		pvclaims[index] = pvclaim
+		defer func() {
+			client.CoreV1().PersistentVolumeClaims(namespace).Delete(pvclaimSpec.Name, nil)
+		}()
+	}
+	By("Waiting for claims status in this thread to become Bound")
+	for _, claim := range pvclaims {
+		err := framework.WaitForPersistentVolumeClaimPhase(v1.ClaimBound, client, claim.Namespace, claim.Name, framework.Poll, framework.ClaimProvisionTimeout)
+		Expect(err).NotTo(HaveOccurred())
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
This PR is the Part-1 of the Stress Test for vSphere Cloud Provider.
Part 1 of the test does following

- Create Storage Classes of 4 Categories (Default, SC with Non Default Datastore, SC with SPBM Policy, SC with VSAN Storage Capalibilies.)
- READ VCP_STRESS_INSTANCES and VCP_STRESS_VOLUMES_PER_INSTANCE from System Environment.
- Launch goroutine for creating volumes `n` times. Here `n` is the value specified by the user in the system env VCP_STRESS_INSTANCES env variable.
- Each instance of routine creates `m` number of volumes using the storage classes created in step-1. Here `m` is value specified by the user in the system env VCP_STRESS_VOLUMES_PER_INSTANCE.

**Which issue this PR fixes**
Issue: https://github.com/vmware/kubernetes/issues/270

**Special notes for your reviewer**:

Set Test Env
```
# export VCP_STRESS_INSTANCES=2
# export VCP_STRESS_VOLUMES_PER_INSTANCE=5
# export VSPHERE_SPBM_GOLD_POLICY=gold
# export VSPHERE_DATASTORE=vsanDatastore
```

Test Logs
```
# go run hack/e2e.go --check-version-skew=false -v -test --test_args='--ginkgo.focus=vsphere\sstress\stests'
flag provided but not defined: -check-version-skew
Usage of /tmp/go-build672964864/command-line-arguments/_obj/exe/e2e:
  -get
    	go get -u kubetest if old or not installed (default true)
  -old duration
    	Consider kubetest old if it exceeds this (default 24h0m0s)
2017/10/02 15:50:33 e2e.go:55: NOTICE: go run hack/e2e.go is now a shim for test-infra/kubetest
2017/10/02 15:50:33 e2e.go:56:   Usage: go run hack/e2e.go [--get=true] [--old=24h0m0s] -- [KUBETEST_ARGS]
2017/10/02 15:50:33 e2e.go:57:   The separator is required to use --get or --old flags
2017/10/02 15:50:33 e2e.go:58:   The -- flag separator also suppresses this message
2017/10/02 15:50:33 e2e.go:77: Calling kubetest --check-version-skew=false -v -test --test_args=--ginkgo.focus=vsphere\sstress\stests...
2017/10/02 15:50:34 util.go:154: Running: ./cluster/kubectl.sh --match-server-version=false version
2017/10/02 15:50:34 util.go:156: Step './cluster/kubectl.sh --match-server-version=false version' finished in 211.709922ms
2017/10/02 15:50:34 util.go:154: Running: ./hack/e2e-internal/e2e-status.sh
Skeleton Provider: prepare-e2e not implemented
Client Version: version.Info{Major:"1", Minor:"6+", GitVersion:"v1.6.0-alpha.0.16774+4161e9117c574f", GitCommit:"4161e9117c574f61facd4bc65c532ea676b4334d", GitTreeState:"clean", BuildDate:"2017-10-02T22:19:33Z", GoVersion:"go1.8.3", Compiler:"gc", Platform:"linux/amd64"}
Server Version: version.Info{Major:"1", Minor:"9+", GitVersion:"v1.9.0-alpha.1.546+6ed207374f8bbf", GitCommit:"6ed207374f8bbff82fe91c6fb6ed66698fce4cdd", GitTreeState:"clean", BuildDate:"2017-10-02T07:14:54Z", GoVersion:"go1.8.3", Compiler:"gc", Platform:"linux/amd64"}
2017/10/02 15:50:34 util.go:156: Step './hack/e2e-internal/e2e-status.sh' finished in 133.914557ms
2017/10/02 15:50:34 util.go:154: Running: ./hack/ginkgo-e2e.sh --ginkgo.focus=vsphere\sstress\stests
Conformance test: not doing test setup.
Oct  2 15:50:34.993: INFO: Overriding default scale value of zero to 1
Oct  2 15:50:34.993: INFO: Overriding default milliseconds value of zero to 5000
I1002 15:50:35.105835    6084 e2e.go:369] Starting e2e run "19f05e7c-a7c4-11e7-8544-0050569c26b8" on Ginkgo node 1
Running Suite: Kubernetes e2e suite
===================================
Random Seed: 1506984634 - Will randomize all specs
Will run 1 of 701 specs

Oct  2 15:50:35.129: INFO: >>> kubeConfig: /root/.kube/config
Oct  2 15:50:35.132: INFO: Waiting up to 4h0m0s for all (but 0) nodes to be schedulable
Oct  2 15:50:35.159: INFO: Waiting up to 10m0s for all pods (need at least 0) in namespace 'kube-system' to be running and ready
Oct  2 15:50:35.229: INFO: 13 / 13 pods in namespace 'kube-system' are running and ready (0 seconds elapsed)
Oct  2 15:50:35.229: INFO: expected 4 pod replicas in namespace 'kube-system', 4 are Running and Ready.
Oct  2 15:50:35.233: INFO: Waiting for pods to enter Success, but no pods in "kube-system" match label map[name:e2e-image-puller]
Oct  2 15:50:35.233: INFO: Dumping network health container logs from all nodes...
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
------------------------------
[sig-storage] vcp-stress 
  vsphere stress tests
  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/storage/vsphere_stress.go:104
[BeforeEach] [sig-storage] vcp-stress
  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
STEP: Creating a kubernetes client
Oct  2 15:50:35.242: INFO: >>> kubeConfig: /root/.kube/config
STEP: Building a namespace api object
STEP: Waiting for a default service account to be provisioned in namespace
[BeforeEach] [sig-storage] vcp-stress
  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/storage/vsphere_stress.go:39
[It] vsphere stress tests
  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/storage/vsphere_stress.go:104
STEP: Creating Storage Class : sc-default
STEP: Creating Storage Class : sc-vsan
STEP: Creating Storage Class : sc-spbm
STEP: Creating Storage Class : sc-user-specified-ds
STEP: Creating PVC using the Storage Class
STEP: Creating PVC using the Storage Class
STEP: Creating PVC using the Storage Class
STEP: Creating PVC using the Storage Class
STEP: Creating PVC using the Storage Class
STEP: Creating PVC using the Storage Class
STEP: Creating PVC using the Storage Class
STEP: Creating PVC using the Storage Class
STEP: Creating PVC using the Storage Class
STEP: Creating PVC using the Storage Class
STEP: Waiting for claims status in this thread to become Bound
Oct  2 15:50:35.425: INFO: Waiting up to 5m0s for PersistentVolumeClaim pvc-b7t7z to have phase Bound
Oct  2 15:50:35.429: INFO: PersistentVolumeClaim pvc-b7t7z found but phase is Pending instead of Bound.
STEP: Waiting for claims status in this thread to become Bound
Oct  2 15:50:35.435: INFO: Waiting up to 5m0s for PersistentVolumeClaim pvc-vxvhd to have phase Bound
Oct  2 15:50:35.444: INFO: PersistentVolumeClaim pvc-vxvhd found but phase is Pending instead of Bound.
Oct  2 15:50:37.434: INFO: PersistentVolumeClaim pvc-b7t7z found but phase is Pending instead of Bound.
Oct  2 15:50:37.448: INFO: PersistentVolumeClaim pvc-vxvhd found and phase=Bound (2.012344128s)
Oct  2 15:50:37.448: INFO: Waiting up to 5m0s for PersistentVolumeClaim pvc-dlf55 to have phase Bound
Oct  2 15:50:37.451: INFO: PersistentVolumeClaim pvc-dlf55 found but phase is Pending instead of Bound.
Oct  2 15:50:39.438: INFO: PersistentVolumeClaim pvc-b7t7z found but phase is Pending instead of Bound.
Oct  2 15:50:39.455: INFO: PersistentVolumeClaim pvc-dlf55 found but phase is Pending instead of Bound.
Oct  2 15:50:41.443: INFO: PersistentVolumeClaim pvc-b7t7z found but phase is Pending instead of Bound.
Oct  2 15:50:41.458: INFO: PersistentVolumeClaim pvc-dlf55 found but phase is Pending instead of Bound.
Oct  2 15:50:43.450: INFO: PersistentVolumeClaim pvc-b7t7z found and phase=Bound (8.024859067s)
Oct  2 15:50:43.450: INFO: Waiting up to 5m0s for PersistentVolumeClaim pvc-cktpb to have phase Bound
Oct  2 15:50:43.454: INFO: PersistentVolumeClaim pvc-cktpb found but phase is Pending instead of Bound.
Oct  2 15:50:43.463: INFO: PersistentVolumeClaim pvc-dlf55 found but phase is Pending instead of Bound.
Oct  2 15:50:45.459: INFO: PersistentVolumeClaim pvc-cktpb found but phase is Pending instead of Bound.
Oct  2 15:50:45.467: INFO: PersistentVolumeClaim pvc-dlf55 found but phase is Pending instead of Bound.
Oct  2 15:50:47.462: INFO: PersistentVolumeClaim pvc-cktpb found but phase is Pending instead of Bound.
Oct  2 15:50:47.470: INFO: PersistentVolumeClaim pvc-dlf55 found and phase=Bound (10.022314318s)
Oct  2 15:50:47.470: INFO: Waiting up to 5m0s for PersistentVolumeClaim pvc-gw47j to have phase Bound
Oct  2 15:50:47.473: INFO: PersistentVolumeClaim pvc-gw47j found but phase is Pending instead of Bound.
Oct  2 15:50:49.467: INFO: PersistentVolumeClaim pvc-cktpb found and phase=Bound (6.016735166s)
Oct  2 15:50:49.467: INFO: Waiting up to 5m0s for PersistentVolumeClaim pvc-c89z2 to have phase Bound
Oct  2 15:50:49.470: INFO: PersistentVolumeClaim pvc-c89z2 found but phase is Pending instead of Bound.
Oct  2 15:50:49.476: INFO: PersistentVolumeClaim pvc-gw47j found but phase is Pending instead of Bound.
Oct  2 15:50:51.475: INFO: PersistentVolumeClaim pvc-c89z2 found but phase is Pending instead of Bound.
Oct  2 15:50:51.480: INFO: PersistentVolumeClaim pvc-gw47j found and phase=Bound (4.010105813s)
Oct  2 15:50:51.480: INFO: Waiting up to 5m0s for PersistentVolumeClaim pvc-t5w8b to have phase Bound
Oct  2 15:50:51.484: INFO: PersistentVolumeClaim pvc-t5w8b found and phase=Bound (3.464704ms)
Oct  2 15:50:51.484: INFO: Waiting up to 5m0s for PersistentVolumeClaim pvc-dkfgf to have phase Bound
Oct  2 15:50:51.487: INFO: PersistentVolumeClaim pvc-dkfgf found and phase=Bound (3.193788ms)
Oct  2 15:50:53.480: INFO: PersistentVolumeClaim pvc-c89z2 found and phase=Bound (4.013289006s)
Oct  2 15:50:53.480: INFO: Waiting up to 5m0s for PersistentVolumeClaim pvc-b8fwn to have phase Bound
Oct  2 15:50:53.484: INFO: PersistentVolumeClaim pvc-b8fwn found and phase=Bound (3.669125ms)
Oct  2 15:50:53.484: INFO: Waiting up to 5m0s for PersistentVolumeClaim pvc-2qn2s to have phase Bound
Oct  2 15:50:53.488: INFO: PersistentVolumeClaim pvc-2qn2s found and phase=Bound (3.580189ms)
[AfterEach] [sig-storage] vcp-stress
  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
Oct  2 15:50:53.534: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
STEP: Destroying namespace "e2e-tests-vcp-stress-2pplw" for this suite.
Oct  2 15:50:59.737: INFO: namespace: e2e-tests-vcp-stress-2pplw, resource: bindings, ignored listing per whitelist
Oct  2 15:50:59.741: INFO: namespace e2e-tests-vcp-stress-2pplw deletion completed in 6.201718208s

• [SLOW TEST:24.499 seconds]
[sig-storage] vcp-stress
/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/storage/framework.go:22
  vsphere stress tests
  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/storage/vsphere_stress.go:104
------------------------------
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSOct  2 15:50:59.745: INFO: Running AfterSuite actions on all node
Oct  2 15:50:59.745: INFO: Running AfterSuite actions on node 1

Ran 1 of 701 Specs in 24.616 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 700 Skipped PASS

Ginkgo ran 1 suite in 25.006286246s
Test Suite Passed
2017/10/02 15:50:59 util.go:156: Step './hack/ginkgo-e2e.sh --ginkgo.focus=vsphere\sstress\stests' finished in 25.403948081s
2017/10/02 15:50:59 e2e.go:81: Done
```


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```

Please review: @BaluDontu @SandeepPissay @rohitjogvmw
