### PR TITLE
Test to verify volume provisioning on a clustered datastore

### DIFF
--- a/test/e2e/storage/BUILD
+++ b/test/e2e/storage/BUILD
@@ -24,6 +24,7 @@ go_library(
         "volume_provisioning.go",
         "volumes.go",
         "vsphere_utils.go",
+        "vsphere_volume_cluster_ds.go"
         "vsphere_volume_diskformat.go",
         "vsphere_volume_fstype.go",
         "vsphere_volume_ops_storm.go",

--- a/test/e2e/storage/vsphere_volume_cluster_ds.go
+++ b/test/e2e/storage/vsphere_volume_cluster_ds.go
@@ -1,0 +1,111 @@
+package storage
+
+import (
+	"os"
+	"strconv"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/pkg/cloudprovider/providers/vsphere"
+	"k8s.io/kubernetes/pkg/cloudprovider/providers/vsphere/vclib"
+	"k8s.io/kubernetes/test/e2e/framework"
+)
+
+/*
+	Tests to verify volume provisioning on a clustered datastore
+	1. Static provisioning
+	2. Dynamic provisioning
+	3. Dynamic provisioning with spbm policy
+
+	This test reads env
+	1. CLUSTER_DATASTORE which should be set to clustered datastore
+	2. VSPHERE_SPBM_POLICY_DS_CLUSTER which should be set to a tag based spbm policy tagged to a clustered datastore
+*/
+var _ = SIGDescribe("Volume Provision On Clustered Datastore", func() {
+	f := framework.NewDefaultFramework("volume-provision")
+
+	var client clientset.Interface
+	var namespace string
+	clusterDatastore := os.Getenv("CLUSTER_DATASTORE")
+	Expect(clusterDatastore).NotTo(BeEmpty())
+	var scParameters map[string]string
+
+	BeforeEach(func() {
+		framework.SkipUnlessProviderIs("vsphere")
+		client = f.ClientSet
+		namespace = f.Namespace.Name
+		scParameters = make(map[string]string)
+	})
+
+	/*
+		Steps:
+		1. Create volume options with datastore to be a clustered datastore
+		2. Create a vsphere volume
+		3. Create podspec with volume path. Create a corresponding pod
+		4. Verify disk is attached
+		5. Delete the pod and wait for the disk to be detached
+	*/
+
+	It("verify static provision", func() {
+		var volumePath string
+		vsp, err := vsphere.GetVSphere()
+		Expect(err).NotTo(HaveOccurred())
+
+		By("creating a test vsphere volume")
+		volumeOptions := new(vclib.VolumeOptions)
+		volumeOptions.CapacityKB = 2097152
+		volumeOptions.Name = "e2e-vmdk-" + strconv.FormatInt(time.Now().UnixNano(), 10)
+		volumeOptions.Datastore = clusterDatastore
+
+		volumePath, err = createVSphereVolume(vsp, volumeOptions)
+		Expect(err).NotTo(HaveOccurred())
+
+		podspec := getVSpherePodSpecWithVolumePaths([]string{volumePath}, nil, nil)
+
+		pod, err := client.CoreV1().Pods(namespace).Create(podspec)
+		Expect(err).NotTo(HaveOccurred())
+		By("Waiting for pod to be ready")
+		Expect(framework.WaitForPodNameRunningInNamespace(client, pod.Name, namespace)).To(Succeed())
+
+		// get fresh pod info
+		pod, err = client.CoreV1().Pods(namespace).Get(pod.Name, metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		nodeName := types.NodeName(pod.Spec.NodeName)
+
+		isAttached, err := verifyVSphereDiskAttached(vsp, volumePath, types.NodeName(nodeName))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(isAttached).To(BeTrue(), "disk:"+volumePath+" is not attached with the node")
+
+		By("Deleting pod")
+		framework.DeletePodWithWait(f, client, pod)
+
+		By("Waiting for volumes to be detached from the node")
+		waitForVSphereDiskToDetach(vsp, volumePath, types.NodeName(nodeName))
+	})
+
+	/*
+		Steps:
+		1. Create storage class parameter and specify datastore to be a clustered datastore name
+		2. invokeValidPolicyTest - util to do e2e dynamic provision test
+	*/
+	It("verify dynamic provision with default parameter", func() {
+		scParameters[Datastore] = clusterDatastore
+		invokeValidPolicyTest(f, client, namespace, scParameters)
+	})
+
+	/*
+		Steps:
+		1. Create storage class parameter and specify storage policy to be a tag based spbm policy
+		2. invokeValidPolicyTest - util to do e2e dynamic provision test
+	*/
+	It("verify dynamic provision with spbm policy", func() {
+		goldPolicy := os.Getenv("VSPHERE_SPBM_POLICY_DS_CLUSTER")
+		Expect(goldPolicy).NotTo(BeEmpty())
+		scParameters[SpbmStoragePolicy] = goldPolicy
+		invokeValidPolicyTest(f, client, namespace, scParameters)
+	})
+})


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR introduces tests for volume provisioning on a clustered datastore. It does so in three ways
1. Static provisioning (create vsphere volume and then create a pod with it)
2. Dynamic provisioning (specify clustered datastore in storage class parameters
3. Dynamic provisioning with spbm policy (specify storage policy name in storage class parameters. This policy is a tag based policy and tagged to a clustered datastore)

**Which issue this PR fixes** : 
fixes #278

**Special notes for your reviewer**:
First 2 tests fail as of now due to the issue #312

**Release note**:
Set env as per following example due to the need mentioned in description
```
export CLUSTER_DATASTORE="dscl1/sharedVmfs-1"
export VSPHERE_SPBM_POLICY_DS_CLUSTER="gold_cluster"
```
Test log for the third test
```
root@k8s-dev-vm-01:~/shahzeb/k8s/kubernetes# go run hack/e2e.go --check-version-skew=false -v -test --test_args='--ginkgo.focus=Volume\sProvision\sClustered\sDatastore\sverify\sdynamic\sprovision\swith\sspbm\spolicy'
flag provided but not defined: -check-version-skew
Usage of /tmp/go-build110689044/command-line-arguments/_obj/exe/e2e:
  -get
    	go get -u kubetest if old or not installed (default true)
  -old duration
    	Consider kubetest old if it exceeds this (default 24h0m0s)
2017/10/03 15:51:02 e2e.go:55: NOTICE: go run hack/e2e.go is now a shim for test-infra/kubetest
2017/10/03 15:51:02 e2e.go:56:   Usage: go run hack/e2e.go [--get=true] [--old=24h0m0s] -- [KUBETEST_ARGS]
2017/10/03 15:51:02 e2e.go:57:   The separator is required to use --get or --old flags
2017/10/03 15:51:02 e2e.go:58:   The -- flag separator also suppresses this message
2017/10/03 15:51:02 e2e.go:77: Calling kubetest --check-version-skew=false -v -test --test_args=--ginkgo.focus=Volume\sProvision\sClustered\sDatastore\sverify\sdynamic\sprovision\swith\sspbm\spolicy...
2017/10/03 15:51:02 util.go:154: Running: ./cluster/kubectl.sh --match-server-version=false version
2017/10/03 15:51:02 util.go:156: Step './cluster/kubectl.sh --match-server-version=false version' finished in 273.258677ms
2017/10/03 15:51:02 util.go:154: Running: ./hack/e2e-internal/e2e-status.sh
Skeleton Provider: prepare-e2e not implemented
Client Version: version.Info{Major:"1", Minor:"6+", GitVersion:"v1.6.0-alpha.0.16728+97d4e7e9d844d0", GitCommit:"97d4e7e9d844d086906a2619e7a5196d5b083088", GitTreeState:"clean", BuildDate:"2017-10-03T20:23:51Z", GoVersion:"go1.8.3", Compiler:"gc", Platform:"linux/amd64"}
Server Version: version.Info{Major:"1", Minor:"9+", GitVersion:"v1.9.0-alpha.1.586+028ee090f64df5", GitCommit:"028ee090f64df569db3e64c8bdd9e74d08480ed2", GitTreeState:"clean", BuildDate:"2017-10-03T07:09:10Z", GoVersion:"go1.8.3", Compiler:"gc", Platform:"linux/amd64"}
2017/10/03 15:51:02 util.go:156: Step './hack/e2e-internal/e2e-status.sh' finished in 281.994643ms
2017/10/03 15:51:02 util.go:154: Running: ./hack/ginkgo-e2e.sh --ginkgo.focus=Volume\sProvision\sClustered\sDatastore\sverify\sdynamic\sprovision\swith\sspbm\spolicy
Conformance test: not doing test setup.
Oct  3 15:51:04.372: INFO: Overriding default scale value of zero to 1
Oct  3 15:51:04.372: INFO: Overriding default milliseconds value of zero to 5000
I1003 15:51:04.597693   15448 e2e.go:369] Starting e2e run "55c83a34-a88d-11e7-83c8-0050569c27f6" on Ginkgo node 1
Running Suite: Kubernetes e2e suite
===================================
Random Seed: 1507071063 - Will randomize all specs
Will run 1 of 703 specs

Oct  3 15:51:04.656: INFO: >>> kubeConfig: /root/.kube/config
Oct  3 15:51:04.665: INFO: Waiting up to 4h0m0s for all (but 0) nodes to be schedulable
Oct  3 15:51:04.698: INFO: Waiting up to 10m0s for all pods (need at least 0) in namespace 'kube-system' to be running and ready
Oct  3 15:51:04.809: INFO: 13 / 13 pods in namespace 'kube-system' are running and ready (0 seconds elapsed)
Oct  3 15:51:04.809: INFO: expected 4 pod replicas in namespace 'kube-system', 4 are Running and Ready.
Oct  3 15:51:04.814: INFO: Waiting for pods to enter Success, but no pods in "kube-system" match label map[name:e2e-image-puller]
Oct  3 15:51:04.814: INFO: Dumping network health container logs from all nodes...
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
------------------------------
[sig-storage] Volume Provision Clustered Datastore
  verify dynamic provision with spbm policy
  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/storage/vsphere_volume_cluster_ds.go:78
[BeforeEach] [sig-storage] Volume Provision Clustered Datastore
  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
STEP: Creating a kubernetes client
Oct  3 15:51:04.847: INFO: >>> kubeConfig: /root/.kube/config
STEP: Building a namespace api object
STEP: Waiting for a default service account to be provisioned in namespace
[BeforeEach] [sig-storage] Volume Provision Clustered Datastore
  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/storage/vsphere_volume_cluster_ds.go:31
[It] verify dynamic provision with spbm policy
  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/storage/vsphere_volume_cluster_ds.go:78
STEP: Creating Storage Class With storage policy params
STEP: Creating PVC using the Storage Class
STEP: Waiting for claim to be in bound phase
Oct  3 15:51:04.932: INFO: Waiting up to 5m0s for PersistentVolumeClaim pvc-mdvwf to have phase Bound
Oct  3 15:51:04.936: INFO: PersistentVolumeClaim pvc-mdvwf found but phase is Pending instead of Bound.
Oct  3 15:51:06.942: INFO: PersistentVolumeClaim pvc-mdvwf found but phase is Pending instead of Bound.
Oct  3 15:51:08.946: INFO: PersistentVolumeClaim pvc-mdvwf found and phase=Bound (4.014294876s)
STEP: Creating pod to attach PV to the node
STEP: Verify the volume is accessible and available in the pod
Oct  3 15:51:23.222: INFO: Running '/root/shahzeb/k8s/kubernetes/_output/dockerized/bin/linux/amd64/kubectl --server=https://10.192.33.252 --kubeconfig=/root/.kube/config exec pvc-tester-zcqqj --namespace=e2e-tests-volume-provision-j6r97 -- /bin/touch /mnt/volume1/emptyFile.txt'
Oct  3 15:51:23.796: INFO: stderr: ""
Oct  3 15:51:23.796: INFO: stdout: ""
STEP: Deleting pod
Oct  3 15:51:23.796: INFO: Deleting pod pvc-tester-zcqqj
Oct  3 15:51:23.802: INFO: Waiting up to 5m0s for pod "pvc-tester-zcqqj" in namespace "e2e-tests-volume-provision-j6r97" to be "terminated due to deadline exceeded"
Oct  3 15:51:23.806: INFO: Pod "pvc-tester-zcqqj": Phase="Running", Reason="", readiness=true. Elapsed: 4.170883ms
Oct  3 15:51:25.811: INFO: Pod "pvc-tester-zcqqj": Phase="Running", Reason="", readiness=true. Elapsed: 2.00921055s
Oct  3 15:51:27.816: INFO: Pod "pvc-tester-zcqqj": Phase="Running", Reason="", readiness=true. Elapsed: 4.013509384s
Oct  3 15:51:29.820: INFO: Pod "pvc-tester-zcqqj": Phase="Running", Reason="", readiness=true. Elapsed: 6.018225343s
Oct  3 15:51:31.825: INFO: Pod "pvc-tester-zcqqj": Phase="Running", Reason="", readiness=true. Elapsed: 8.02303959s
Oct  3 15:51:33.831: INFO: Pod "pvc-tester-zcqqj": Phase="Running", Reason="", readiness=true. Elapsed: 10.028328257s
Oct  3 15:51:35.836: INFO: Pod "pvc-tester-zcqqj": Phase="Running", Reason="", readiness=true. Elapsed: 12.033525804s
Oct  3 15:51:37.840: INFO: Pod "pvc-tester-zcqqj": Phase="Running", Reason="", readiness=true. Elapsed: 14.038061898s
Oct  3 15:51:39.845: INFO: Pod "pvc-tester-zcqqj": Phase="Running", Reason="", readiness=true. Elapsed: 16.043103531s
Oct  3 15:51:41.852: INFO: Pod "pvc-tester-zcqqj": Phase="Running", Reason="", readiness=true. Elapsed: 18.049572622s
Oct  3 15:51:43.856: INFO: Pod "pvc-tester-zcqqj": Phase="Running", Reason="", readiness=true. Elapsed: 20.054019475s
Oct  3 15:51:45.863: INFO: Pod "pvc-tester-zcqqj": Phase="Running", Reason="", readiness=true. Elapsed: 22.060636921s
Oct  3 15:51:47.868: INFO: Pod "pvc-tester-zcqqj": Phase="Running", Reason="", readiness=true. Elapsed: 24.066195711s
Oct  3 15:51:49.874: INFO: Pod "pvc-tester-zcqqj": Phase="Running", Reason="", readiness=true. Elapsed: 26.071450142s
Oct  3 15:51:51.878: INFO: Pod "pvc-tester-zcqqj": Phase="Running", Reason="", readiness=true. Elapsed: 28.075519583s
Oct  3 15:51:53.882: INFO: Pod "pvc-tester-zcqqj": Phase="Running", Reason="", readiness=true. Elapsed: 30.079971876s
Oct  3 15:51:55.888: INFO: Pod "pvc-tester-zcqqj": Phase="Running", Reason="", readiness=false. Elapsed: 32.085279401s
Oct  3 15:51:57.893: INFO: Pod "pvc-tester-zcqqj": Phase="Running", Reason="", readiness=false. Elapsed: 34.090531551s
Oct  3 15:51:59.897: INFO: Pod "pvc-tester-zcqqj": Phase="Running", Reason="", readiness=false. Elapsed: 36.095155629s
Oct  3 15:52:01.902: INFO: Pod "pvc-tester-zcqqj": Phase="Running", Reason="", readiness=false. Elapsed: 38.100213636s
Oct  3 15:52:03.907: INFO: Pod "pvc-tester-zcqqj": Phase="Running", Reason="", readiness=false. Elapsed: 40.105118466s
Oct  3 15:52:05.912: INFO: Pod "pvc-tester-zcqqj": Phase="Running", Reason="", readiness=false. Elapsed: 42.110153693s
Oct  3 15:52:07.917: INFO: Pod "pvc-tester-zcqqj": Phase="Running", Reason="", readiness=false. Elapsed: 44.115054963s
Oct  3 15:52:09.922: INFO: Pod "pvc-tester-zcqqj": Phase="Running", Reason="", readiness=false. Elapsed: 46.120068421s
Oct  3 15:52:11.928: INFO: Pod "pvc-tester-zcqqj": Phase="Running", Reason="", readiness=false. Elapsed: 48.125979211s
Oct  3 15:52:13.935: INFO: Pod "pvc-tester-zcqqj": Phase="Running", Reason="", readiness=false. Elapsed: 50.132820586s
Oct  3 15:52:15.940: INFO: Pod "pvc-tester-zcqqj": Phase="Running", Reason="", readiness=false. Elapsed: 52.137939075s
Oct  3 15:52:17.946: INFO: Pod "pvc-tester-zcqqj": Phase="Running", Reason="", readiness=false. Elapsed: 54.143528354s
Oct  3 15:52:19.951: INFO: Pod "pvc-tester-zcqqj": Phase="Running", Reason="", readiness=false. Elapsed: 56.148832655s
Oct  3 15:52:21.956: INFO: Pod "pvc-tester-zcqqj": Phase="Running", Reason="", readiness=false. Elapsed: 58.153799299s
Oct  3 15:52:23.961: INFO: Pod "pvc-tester-zcqqj" in namespace "e2e-tests-volume-provision-j6r97" not found. Error: pods "pvc-tester-zcqqj" not found
Oct  3 15:52:23.961: INFO: Ignore "not found" error above. Pod "pvc-tester-zcqqj" successfully deleted
STEP: Waiting for volumes to be detached from the node
Oct  3 15:52:34.090: INFO: Volume "[sharedVmfs-1] kubevols/kubernetes-dynamic-pvc-5642ab59-a88d-11e7-b679-0050569c7cc9.vmdk" appears to have successfully detached from "kubernetes-node3".
Oct  3 15:52:34.090: INFO: Deleting PersistentVolumeClaim "pvc-mdvwf"
[AfterEach] [sig-storage] Volume Provision Clustered Datastore
  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
Oct  3 15:52:34.108: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
STEP: Destroying namespace "e2e-tests-volume-provision-j6r97" for this suite.
Oct  3 15:52:40.237: INFO: namespace: e2e-tests-volume-provision-j6r97, resource: bindings, ignored listing per whitelist
Oct  3 15:52:40.286: INFO: namespace e2e-tests-volume-provision-j6r97 deletion completed in 6.16702444s

• [SLOW TEST:95.439 seconds]
[sig-storage] Volume Provision Clustered Datastore
/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/storage/framework.go:22
  verify dynamic provision with spbm policy
  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/storage/vsphere_volume_cluster_ds.go:78
------------------------------
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSOct  3 15:52:40.287: INFO: Running AfterSuite actions on all node
Oct  3 15:52:40.287: INFO: Running AfterSuite actions on node 1

Ran 1 of 703 Specs in 95.631 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 702 Skipped PASS
```
