### PR TITLE
Attach persistent volumes at user configured scale - Part2 of VCP Scale Test

### DIFF
--- a/test/e2e/framework/pv_util.go
+++ b/test/e2e/framework/pv_util.go
@@ -793,12 +793,12 @@ func deletePD(pdName string) error {
 // Returns a pod definition based on the namespace. The pod references the PVC's
 // name.
 func MakeWritePod(ns string, pvc *v1.PersistentVolumeClaim) *v1.Pod {
-	return MakePod(ns, []*v1.PersistentVolumeClaim{pvc}, true, "touch /mnt/volume1/SUCCESS && (id -G | grep -E '\\b777\\b')")
+	return MakePod(ns, nil, []*v1.PersistentVolumeClaim{pvc}, true, "touch /mnt/volume1/SUCCESS && (id -G | grep -E '\\b777\\b')")
 }
 
 // Returns a pod definition based on the namespace. The pod references the PVC's
 // name.  A slice of BASH commands can be supplied as args to be run by the pod
-func MakePod(ns string, pvclaims []*v1.PersistentVolumeClaim, isPrivileged bool, command string) *v1.Pod {
+func MakePod(ns string, nodeSelector map[string]string, pvclaims []*v1.PersistentVolumeClaim, isPrivileged bool, command string) *v1.Pod {
 	if len(command) == 0 {
 		command = "while true; do sleep 1; done"
 	}
@@ -835,6 +835,9 @@ func MakePod(ns string, pvclaims []*v1.PersistentVolumeClaim, isPrivileged bool,
 	}
 	podSpec.Spec.Containers[0].VolumeMounts = volumeMounts
 	podSpec.Spec.Volumes = volumes
+	if nodeSelector != nil {
+		podSpec.Spec.NodeSelector = nodeSelector
+	}
 	return podSpec
 }
 
@@ -889,9 +892,9 @@ func MakeSecPod(ns string, pvclaims []*v1.PersistentVolumeClaim, isPrivileged bo
 	return podSpec
 }
 
-// create pod with given claims
-func CreatePod(client clientset.Interface, namespace string, pvclaims []*v1.PersistentVolumeClaim, isPrivileged bool, command string) (*v1.Pod, error) {
-	pod := MakePod(namespace, pvclaims, isPrivileged, command)
+// CreatePod with given claims based on node selector
+func CreatePod(client clientset.Interface, namespace string, nodeSelector map[string]string, pvclaims []*v1.PersistentVolumeClaim, isPrivileged bool, command string) (*v1.Pod, error) {
+	pod := MakePod(namespace, nodeSelector, pvclaims, isPrivileged, command)
 	pod, err := client.CoreV1().Pods(namespace).Create(pod)
 	if err != nil {
 		return nil, fmt.Errorf("pod Create API error: %v", err)
@@ -931,7 +934,7 @@ func CreateSecPod(client clientset.Interface, namespace string, pvclaims []*v1.P
 
 // Define and create a pod with a mounted PV.  Pod runs infinite loop until killed.
 func CreateClientPod(c clientset.Interface, ns string, pvc *v1.PersistentVolumeClaim) (*v1.Pod, error) {
-	return CreatePod(c, ns, []*v1.PersistentVolumeClaim{pvc}, true, "")
+	return CreatePod(c, ns, nil, []*v1.PersistentVolumeClaim{pvc}, true, "")
 }
 
 // wait until all pvcs phase set to bound

--- a/test/e2e/storage/BUILD
+++ b/test/e2e/storage/BUILD
@@ -23,6 +23,7 @@ go_library(
         "volume_metrics.go",
         "volume_provisioning.go",
         "volumes.go",
+        "vsphere_scale.go",
         "vsphere_utils.go",
         "vsphere_volume_diskformat.go",
         "vsphere_volume_fstype.go",

--- a/test/e2e/storage/persistent_volumes-disruptive.go
+++ b/test/e2e/storage/persistent_volumes-disruptive.go
@@ -151,7 +151,7 @@ var _ = SIGDescribe("PersistentVolumes[Disruptive][Flaky]", func() {
 			framework.ExpectNoError(framework.WaitOnPVandPVC(c, ns, pv2, pvc2))
 
 			By("Attaching both PVC's to a single pod")
-			clientPod, err = framework.CreatePod(c, ns, []*v1.PersistentVolumeClaim{pvc1, pvc2}, true, "")
+			clientPod, err = framework.CreatePod(c, ns, nil, []*v1.PersistentVolumeClaim{pvc1, pvc2}, true, "")
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -309,7 +309,7 @@ func initTestCase(f *framework.Framework, c clientset.Interface, pvConfig framew
 		}
 	}()
 	Expect(err).NotTo(HaveOccurred())
-	pod := framework.MakePod(ns, []*v1.PersistentVolumeClaim{pvc}, true, "")
+	pod := framework.MakePod(ns, nil, []*v1.PersistentVolumeClaim{pvc}, true, "")
 	pod.Spec.NodeName = nodeName
 	framework.Logf("Creating NFS client pod.")
 	pod, err = c.CoreV1().Pods(ns).Create(pod)

--- a/test/e2e/storage/persistent_volumes.go
+++ b/test/e2e/storage/persistent_volumes.go
@@ -295,7 +295,7 @@ var _ = SIGDescribe("PersistentVolumes", func() {
 				// If a file is detected in /mnt, fail the pod and do not restart it.
 				By("Verifying the mount has been cleaned.")
 				mount := pod.Spec.Containers[0].VolumeMounts[0].MountPath
-				pod = framework.MakePod(ns, []*v1.PersistentVolumeClaim{pvc}, true, fmt.Sprintf("[ $(ls -A %s | wc -l) -eq 0 ] && exit 0 || exit 1", mount))
+				pod = framework.MakePod(ns, nil, []*v1.PersistentVolumeClaim{pvc}, true, fmt.Sprintf("[ $(ls -A %s | wc -l) -eq 0 ] && exit 0 || exit 1", mount))
 				pod, err = c.CoreV1().Pods(ns).Create(pod)
 				Expect(err).NotTo(HaveOccurred())
 				framework.ExpectNoError(framework.WaitForPodSuccessInNamespace(c, pod.Name, ns))

--- a/test/e2e/storage/volume_metrics.go
+++ b/test/e2e/storage/volume_metrics.go
@@ -87,7 +87,7 @@ var _ = SIGDescribe("[Serial] Volume metrics", func() {
 
 		claims := []*v1.PersistentVolumeClaim{pvc}
 
-		pod := framework.MakePod(ns, claims, false, "")
+		pod := framework.MakePod(ns, nil, claims, false, "")
 		pod, err = c.CoreV1().Pods(ns).Create(pod)
 		Expect(err).NotTo(HaveOccurred())
 
@@ -135,7 +135,7 @@ var _ = SIGDescribe("[Serial] Volume metrics", func() {
 		Expect(pvc).ToNot(Equal(nil))
 
 		claims := []*v1.PersistentVolumeClaim{pvc}
-		pod := framework.MakePod(ns, claims, false, "")
+		pod := framework.MakePod(ns, nil, claims, false, "")
 		pod, err = c.CoreV1().Pods(ns).Create(pod)
 		Expect(err).NotTo(HaveOccurred())
 

--- a/test/e2e/storage/vsphere_scale.go
+++ b/test/e2e/storage/vsphere_scale.go
@@ -1,0 +1,234 @@
+package storage
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/api/core/v1"
+	storageV1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/pkg/cloudprovider/providers/vsphere"
+	"k8s.io/kubernetes/test/e2e/framework"
+)
+
+/*
+	Perform vsphere volume life cycle management at scale based on user configurable value for number of volumes.
+	The following actions will be performed as part of this test.
+
+	1. Create Storage Classes of 4 Categories (Default, SC with Non Default Datastore, SC with SPBM Policy, SC with VSAN Storage Capalibilies.)
+	2. Read VCP_SCALE_VOLUME_COUNT from System Environment.
+	3. Launch VCP_SCALE_INSTANCES goroutine for creating VCP_SCALE_VOLUME_COUNT volumes. Each goroutine is responsible for create/attach of VCP_SCALE_VOLUME_COUNT/VCP_SCALE_INSTANCES volumes.
+	4. Read VCP_SCALE_VOLUMES_PER_POD from System Environment. Each pod will be have VCP_SCALE_VOLUMES_PER_POD attached to it.
+	5. Once all the go routines are completed, we delete all the pods and volumes.
+*/
+const (
+	NodeLabelKey              = "vsphere_e2e_label"
+	SCSIUnitsAvailablePerNode = 55
+)
+
+// NodeSelector holds
+type NodeSelector struct {
+	labelKey   string
+	labelValue string
+}
+
+var _ = SIGDescribe("vcp at scale [Feature:vsphere] ", func() {
+	f := framework.NewDefaultFramework("vcp-at-scale")
+
+	var (
+		client            clientset.Interface
+		namespace         string
+		nodeSelectorList  []*NodeSelector
+		volumeCount       int
+		numberOfInstances int
+		volumesPerPod     int
+		nodeVolumeMapChan chan map[string][]string
+		nodes             *v1.NodeList
+	)
+
+	BeforeEach(func() {
+		var err error
+		framework.SkipUnlessProviderIs("vsphere")
+		client = f.ClientSet
+		namespace = f.Namespace.Name
+		nodeVolumeMapChan = make(chan map[string][]string)
+		Expect(os.Getenv("VCP_SCALE_VOLUME_COUNT")).NotTo(BeEmpty(), "ENV VCP_SCALE_VOLUME_COUNT is not set")
+		Expect(os.Getenv("VSPHERE_SPBM_GOLD_POLICY")).NotTo(BeEmpty(), "ENV VSPHERE_SPBM_GOLD_POLICY is not set")
+		Expect(os.Getenv("VSPHERE_DATASTORE")).NotTo(BeEmpty(), "ENV VSPHERE_DATASTORE is not set")
+
+		volumesPerPod, err = strconv.Atoi(os.Getenv("VCP_SCALE_VOLUME_PER_POD"))
+		Expect(err).NotTo(HaveOccurred(), "Error Parsing VCP_SCALE_VOLUME_PER_POD")
+
+		numberOfInstances, err = strconv.Atoi(os.Getenv("VCP_SCALE_INSTANCES"))
+		Expect(err).NotTo(HaveOccurred(), "Error Parsing VCP_SCALE_INSTANCES")
+
+		// Verify volume count specified by the user can be satisfied
+		volumeCount, err = strconv.Atoi(os.Getenv("VCP_SCALE_VOLUME_COUNT"))
+		Expect(err).NotTo(HaveOccurred(), "Error Parsing VCP_SCALE_VOLUME_COUNT")
+		nodes = framework.GetReadySchedulableNodesOrDie(client)
+		if len(nodes.Items) < 2 {
+			framework.Skipf("Requires at least %d nodes (not %d)", 2, len(nodes.Items))
+		}
+		if volumeCount > SCSIUnitsAvailablePerNode*len(nodes.Items) {
+			framework.Skipf("Cannot attach %d volumes to %d nodes. Maximum volumes that can be attached on %d nodes is %d", volumeCount, len(nodes.Items), len(nodes.Items), SCSIUnitsAvailablePerNode*len(nodes.Items))
+		}
+		nodeSelectorList = createNodeLabels(client, namespace, nodes)
+	})
+
+	/*
+		Remove labels from all the nodes
+	*/
+	framework.AddCleanupAction(func() {
+		for _, node := range nodes.Items {
+			framework.RemoveLabelOffNode(client, node.Name, NodeLabelKey)
+		}
+	})
+
+	It("vsphere scale tests", func() {
+		var pvcClaimList []string
+		nodeVolumeMap := make(map[k8stypes.NodeName][]string)
+		// Volumes will be provisioned with each different types of Storage Class
+		scArrays := make([]*storageV1.StorageClass, 4)
+		// Create default vSphere Storage Class
+		By("Creating Storage Class : sc-default")
+		scDefaultSpec := getVSphereStorageClassSpec("sc-default", nil)
+		scDefault, err := client.StorageV1().StorageClasses().Create(scDefaultSpec)
+		Expect(err).NotTo(HaveOccurred())
+		defer client.StorageV1().StorageClasses().Delete(scDefault.Name, nil)
+		scArrays[0] = scDefault
+
+		// Create Storage Class with vsan storage capabilities
+		By("Creating Storage Class : sc-vsan")
+		var scvsanParameters map[string]string
+		scvsanParameters = make(map[string]string)
+		scvsanParameters[Policy_HostFailuresToTolerate] = "1"
+		scvsanSpec := getVSphereStorageClassSpec("sc-vsan", scvsanParameters)
+		scvsan, err := client.StorageV1().StorageClasses().Create(scvsanSpec)
+		Expect(err).NotTo(HaveOccurred())
+		defer client.StorageV1().StorageClasses().Delete(scvsan.Name, nil)
+		scArrays[1] = scvsan
+
+		// Create Storage Class with SPBM Policy
+		By("Creating Storage Class : sc-spbm")
+		var scSpbmPolicyParameters map[string]string
+		scSpbmPolicyParameters = make(map[string]string)
+		goldPolicy := os.Getenv("VSPHERE_SPBM_GOLD_POLICY")
+		Expect(goldPolicy).NotTo(BeEmpty())
+		scSpbmPolicyParameters[SpbmStoragePolicy] = goldPolicy
+		scSpbmPolicySpec := getVSphereStorageClassSpec("sc-spbm", scSpbmPolicyParameters)
+		scSpbmPolicy, err := client.StorageV1().StorageClasses().Create(scSpbmPolicySpec)
+		Expect(err).NotTo(HaveOccurred())
+		defer client.StorageV1().StorageClasses().Delete(scSpbmPolicy.Name, nil)
+		scArrays[2] = scSpbmPolicy
+
+		// Create Storage Class with User Specified Datastore.
+		By("Creating Storage Class : sc-user-specified-datastore")
+		var scWithDatastoreParameters map[string]string
+		scWithDatastoreParameters = make(map[string]string)
+		datastore := os.Getenv("VSPHERE_DATASTORE")
+		Expect(goldPolicy).NotTo(BeEmpty())
+		scWithDatastoreParameters[Datastore] = datastore
+		scWithDatastoreSpec := getVSphereStorageClassSpec("sc-user-specified-ds", scWithDatastoreParameters)
+		scWithDatastore, err := client.StorageV1().StorageClasses().Create(scWithDatastoreSpec)
+		Expect(err).NotTo(HaveOccurred())
+		defer client.StorageV1().StorageClasses().Delete(scWithDatastore.Name, nil)
+		scArrays[3] = scWithDatastore
+
+		vsp, err := vsphere.GetVSphere()
+		Expect(err).NotTo(HaveOccurred())
+
+		volumeCountPerInstance := volumeCount / numberOfInstances
+		for instanceCount := 0; instanceCount < numberOfInstances; instanceCount++ {
+			if instanceCount == numberOfInstances-1 {
+				volumeCountPerInstance = volumeCount
+			}
+			volumeCount = volumeCount - volumeCountPerInstance
+			go VolumeCreateAndAttach(client, namespace, scArrays, volumeCountPerInstance, volumesPerPod, nodeSelectorList, nodeVolumeMapChan, vsp)
+		}
+
+		// Get the list of all volumes attached to each node from the go routines by reading the data from the channel
+		for instanceCount := 0; instanceCount < numberOfInstances; instanceCount++ {
+			for node, volumeList := range <-nodeVolumeMapChan {
+				nodeVolumeMap[k8stypes.NodeName(node)] = append(nodeVolumeMap[k8stypes.NodeName(node)], volumeList...)
+			}
+		}
+		podList, err := client.CoreV1().Pods(namespace).List(metav1.ListOptions{})
+		for _, pod := range podList.Items {
+			pvcClaimList = append(pvcClaimList, getClaimsForPod(&pod, volumesPerPod)...)
+			By("Deleting pod")
+			framework.DeletePodWithWait(f, client, &pod)
+		}
+		By("Waiting for volumes to be detached from the node")
+		err = waitForVSphereDisksToDetach(vsp, nodeVolumeMap)
+		Expect(err).NotTo(HaveOccurred())
+
+		for _, pvcClaim := range pvcClaimList {
+			err = framework.DeletePersistentVolumeClaim(client, pvcClaim, namespace)
+			Expect(err).NotTo(HaveOccurred())
+		}
+	})
+})
+
+// Get PVC claims for the pod
+func getClaimsForPod(pod *v1.Pod, volumesPerPod int) []string {
+	pvcClaimList := make([]string, volumesPerPod)
+	for i, volumespec := range pod.Spec.Volumes {
+		if volumespec.PersistentVolumeClaim != nil {
+			pvcClaimList[i] = volumespec.PersistentVolumeClaim.ClaimName
+		}
+	}
+	return pvcClaimList
+}
+
+// VolumeCreateAndAttach peforms create and attach operations of vSphere persistent volumes at scale
+func VolumeCreateAndAttach(client clientset.Interface, namespace string, sc []*storageV1.StorageClass, volumeCountPerInstance int, volumesPerPod int, nodeSelectorList []*NodeSelector, nodeVolumeMapChan chan map[string][]string, vsp *vsphere.VSphere) {
+	defer GinkgoRecover()
+	nodeVolumeMap := make(map[string][]string)
+	nodeSelectorIndex := 0
+	for index := 0; index < volumeCountPerInstance; index = index + volumesPerPod {
+		pvclaims := make([]*v1.PersistentVolumeClaim, volumesPerPod)
+		for i := 0; i < volumesPerPod; i++ {
+			By(fmt.Sprintf("Creating PVC%q using the Storage Class", index+1))
+			pvclaim, err := framework.CreatePVC(client, namespace, getVSphereClaimSpecWithStorageClassAnnotation(namespace, sc[index%len(sc)]))
+			Expect(err).NotTo(HaveOccurred())
+			pvclaims[i] = pvclaim
+		}
+
+		By("Waiting for claim to be in bound phase")
+		persistentvolumes, err := framework.WaitForPVClaimBoundPhase(client, pvclaims)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Creating pod to attach PV to the node")
+		nodeSelector := nodeSelectorList[index%len(nodeSelectorList)]
+		// Create pod to attach Volume to Node
+		pod, err := framework.CreatePod(client, namespace, map[string]string{nodeSelector.labelKey: nodeSelector.labelValue}, pvclaims, false, "")
+		Expect(err).NotTo(HaveOccurred())
+
+		for _, pv := range persistentvolumes {
+			nodeVolumeMap[pod.Spec.NodeName] = append(nodeVolumeMap[pod.Spec.NodeName], pv.Spec.VsphereVolume.VolumePath)
+		}
+		By("Verify the volume is accessible and available in the pod")
+		verifyVSphereVolumesAccessible(pod, persistentvolumes, vsp)
+		nodeSelectorIndex++
+	}
+	nodeVolumeMapChan <- nodeVolumeMap
+}
+
+func createNodeLabels(client clientset.Interface, namespace string, nodes *v1.NodeList) []*NodeSelector {
+	var nodeSelectorList []*NodeSelector
+	for i, node := range nodes.Items {
+		labelVal := "vsphere_e2e_" + strconv.Itoa(i)
+		nodeSelector := &NodeSelector{
+			labelKey:   NodeLabelKey,
+			labelValue: labelVal,
+		}
+		nodeSelectorList = append(nodeSelectorList, nodeSelector)
+		framework.AddOrUpdateLabelOnNode(client, node.Name, NodeLabelKey, labelVal)
+	}
+	return nodeSelectorList
+}

--- a/test/e2e/storage/vsphere_volume_fstype.go
+++ b/test/e2e/storage/vsphere_volume_fstype.go
@@ -91,7 +91,7 @@ func invokeTestForFstype(f *framework.Framework, client clientset.Interface, nam
 
 	By("Creating pod to attach PV to the node")
 	// Create pod to attach Volume to Node
-	pod, err := framework.CreatePod(client, namespace, pvclaims, false, "")
+	pod, err := framework.CreatePod(client, namespace, nil, pvclaims, false, "")
 	Expect(err).NotTo(HaveOccurred())
 
 	// Asserts: Right disk is attached to the pod

--- a/test/e2e/storage/vsphere_volume_ops_storm.go
+++ b/test/e2e/storage/vsphere_volume_ops_storm.go
@@ -109,7 +109,7 @@ var _ = SIGDescribe("vsphere volume operations storm", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Creating pod to attach PVs to the node")
-		pod, err := framework.CreatePod(client, namespace, pvclaims, false, "")
+		pod, err := framework.CreatePod(client, namespace, nil, pvclaims, false, "")
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Verify all volumes are accessible and available in the pod")

--- a/test/e2e/storage/vsphere_volume_vsan_policy.go
+++ b/test/e2e/storage/vsphere_volume_vsan_policy.go
@@ -274,7 +274,7 @@ func invokeValidPolicyTest(f *framework.Framework, client clientset.Interface, n
 
 	By("Creating pod to attach PV to the node")
 	// Create pod to attach Volume to Node
-	pod, err := framework.CreatePod(client, namespace, pvclaims, false, "")
+	pod, err := framework.CreatePod(client, namespace, nil, pvclaims, false, "")
 	Expect(err).NotTo(HaveOccurred())
 
 	vsp, err := vsphere.GetVSphere()

--- a/test/e2e/ubernetes_lite.go
+++ b/test/e2e/ubernetes_lite.go
@@ -309,7 +309,7 @@ func PodsUseStaticPVsOrFail(f *framework.Framework, podCount int, image string) 
 
 	By("Creating pods for each static PV")
 	for _, config := range configs {
-		podConfig := framework.MakePod(ns, []*v1.PersistentVolumeClaim{config.pvc}, false, "")
+		podConfig := framework.MakePod(ns, nil, []*v1.PersistentVolumeClaim{config.pvc}, false, "")
 		config.pod, err = c.Core().Pods(ns).Create(podConfig)
 		Expect(err).NotTo(HaveOccurred())
 	}

--- a/test/e2e/upgrades/storage/persistent_volumes.go
+++ b/test/e2e/upgrades/storage/persistent_volumes.go
@@ -98,7 +98,7 @@ func (t *PersistentVolumeUpgradeTest) Teardown(f *framework.Framework) {
 
 // testPod creates a pod that consumes a pv and prints it out. The output is then verified.
 func (t *PersistentVolumeUpgradeTest) testPod(f *framework.Framework, cmd string) {
-	pod := framework.MakePod(f.Namespace.Name, []*v1.PersistentVolumeClaim{t.pvc}, false, cmd)
+	pod := framework.MakePod(f.Namespace.Name, nil, []*v1.PersistentVolumeClaim{t.pvc}, false, cmd)
 	expectedOutput := []string{pvTestData}
 	f.TestContainerOutput("pod consumes pv", pod, 0, expectedOutput)
 }


### PR DESCRIPTION
In this part of PR, we do the following.

- Create labels on each of the nodes in the kubernetes cluster. This node selector would be useful for pod placement.
- Launch VCP_SCALE_INSTANCES go routine for creating VCP_SCALE_VOLUME_COUNT volumes. Each go routine is responsible for create of VCP_SCALE_VOLUME_COUNT/VCP_SCALE_INSTANCES volumes. 
- Read VCP_SCALE_VOLUMES_PER_POD from System Environment. Each pod will be have VCP_SCALE_VOLUMES_PER_POD attached to it. We create the pod on a node based on the node selector. VCP_SCALE_VOLUMES_PER_POD will be using one of the storage class - default, SPBM, VSAN storage capabilities, user specified datastore. 
- The main thread will wait for all the go routines to complete the create and attach. One they are all done, it will clean up the pods and the volumes (PVC's).

Fixes PR - https://github.com/vmware/kubernetes/issues/296