### PR TITLE
Implement Node poweroff test

### DIFF
--- a/test/e2e/framework/deployment_util.go
+++ b/test/e2e/framework/deployment_util.go
@@ -22,9 +22,11 @@ import (
 
 	. "github.com/onsi/ginkgo"
 
+	"github.com/golang/glog"
 	"k8s.io/api/core/v1"
 	extensions "k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 	clientset "k8s.io/client-go/kubernetes"
@@ -307,4 +309,87 @@ func WaitForDeploymentRevision(c clientset.Interface, d *extensions.Deployment, 
 		return fmt.Errorf("error waiting for revision to become %q for deployment %q: %v", targetRevision, d.Name, err)
 	}
 	return nil
+}
+
+func CreateDeployment(client clientset.Interface, replicas int32, podLabels map[string]string, namespace string, pvclaims []*v1.PersistentVolumeClaim, command string) (*extensions.Deployment, error) {
+	deploymentSpec := MakeDeployment(replicas, podLabels, namespace, pvclaims, false, command)
+	deployment, err := client.Extensions().Deployments(namespace).Create(deploymentSpec)
+	if err != nil {
+		return nil, fmt.Errorf("deployment %q Create API error: %v", deploymentSpec.Name, err)
+	}
+	glog.Infof(fmt.Sprintf("Waiting deployment %q to complete", deploymentSpec.Name))
+	err = WaitForDeploymentStatusValid(client, deployment)
+	if err != nil {
+		return nil, fmt.Errorf("deployment %q failed to complete: %v", deploymentSpec.Name, err)
+	}
+	return deployment, nil
+}
+
+// MakeDeployment creates a deployment definition based on the namespace. The deployment references the PVC's
+// name.  A slice of BASH commands can be supplied as args to be run by the pod
+func MakeDeployment(replicas int32, podLabels map[string]string, namespace string, pvclaims []*v1.PersistentVolumeClaim, isPrivileged bool, command string) *extensions.Deployment {
+	if len(command) == 0 {
+		command = "while true; do sleep 1; done"
+	}
+	zero := int64(0)
+	deploymentName := "deployment-" + string(uuid.NewUUID())
+	deploymentSpec := &extensions.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      deploymentName,
+			Namespace: namespace,
+		},
+		Spec: extensions.DeploymentSpec{
+			Replicas: &replicas,
+			Template: v1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: podLabels,
+				},
+				Spec: v1.PodSpec{
+					TerminationGracePeriodSeconds: &zero,
+					Containers: []v1.Container{
+						{
+							Name:    "write-pod",
+							Image:   "busybox",
+							Command: []string{"/bin/sh"},
+							Args:    []string{"-c", command},
+							SecurityContext: &v1.SecurityContext{
+								Privileged: &isPrivileged,
+							},
+						},
+					},
+					RestartPolicy: v1.RestartPolicyAlways,
+				},
+			},
+		},
+	}
+	var volumeMounts = make([]v1.VolumeMount, len(pvclaims))
+	var volumes = make([]v1.Volume, len(pvclaims))
+	for index, pvclaim := range pvclaims {
+		volumename := fmt.Sprintf("volume%v", index+1)
+		volumeMounts[index] = v1.VolumeMount{Name: volumename, MountPath: "/mnt/" + volumename}
+		volumes[index] = v1.Volume{Name: volumename, VolumeSource: v1.VolumeSource{PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{ClaimName: pvclaim.Name, ReadOnly: false}}}
+	}
+	deploymentSpec.Spec.Template.Spec.Containers[0].VolumeMounts = volumeMounts
+	deploymentSpec.Spec.Template.Spec.Volumes = volumes
+	return deploymentSpec
+}
+
+// GetPodsForDeployment gets pods for the given deployment
+func GetPodsForDeployment(client clientset.Interface, deployment *extensions.Deployment) (*v1.PodList, error) {
+	replicaSet, err := deploymentutil.GetNewReplicaSet(deployment, client.ExtensionsV1beta1())
+	if err != nil {
+		return nil, fmt.Errorf("Failed to get new replica set for deployment %q: %v", deployment.Name, err)
+	}
+	if replicaSet == nil {
+		return nil, fmt.Errorf("expected a new replica set for deployment %q, found none", deployment.Name)
+	}
+	podListFunc := func(namespace string, options metav1.ListOptions) (*v1.PodList, error) {
+		return client.Core().Pods(namespace).List(options)
+	}
+	rsList := []*extensions.ReplicaSet{replicaSet}
+	podList, err := deploymentutil.ListPods(deployment, rsList, podListFunc)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to list Pods of Deployment %q: %v", deployment.Name, err)
+	}
+	return podList, nil
 }

--- a/test/e2e/storage/BUILD
+++ b/test/e2e/storage/BUILD
@@ -30,6 +30,7 @@ go_library(
         "vsphere_volume_diskformat.go",
         "vsphere_volume_disksize.go",
         "vsphere_volume_fstype.go",
+        "vsphere_volume_node_poweroff.go",
         "vsphere_volume_ops_storm.go",
         "vsphere_volume_placement.go",
         "vsphere_volume_vsan_policy.go",

--- a/test/e2e/storage/vsphere_utils.go
+++ b/test/e2e/storage/vsphere_utils.go
@@ -38,6 +38,14 @@ import (
 	"k8s.io/kubernetes/test/e2e/framework"
 )
 
+// volumeState represents the state of a volume.
+type volumeState int32
+
+const (
+	volumeStateDetached volumeState = 1
+	volumeStateAttached volumeState = 2
+)
+
 // Sanity check for vSphere testing.  Verify the persistent disk attached to the node.
 func verifyVSphereDiskAttached(vsp *vsphere.VSphere, volumePath string, nodeName types.NodeName) (bool, error) {
 	var (
@@ -53,40 +61,66 @@ func verifyVSphereDiskAttached(vsp *vsphere.VSphere, volumePath string, nodeName
 	return isAttached, err
 }
 
-// Wait until vsphere vmdk is deteched from the given node or time out after 5 minutes
-func waitForVSphereDiskToDetach(vsp *vsphere.VSphere, volumePath string, nodeName types.NodeName) error {
+// Wait until vsphere vmdk moves to expected state on the given node, or time out after 6 minutes
+func waitForVSphereDiskStatus(vsp *vsphere.VSphere, volumePath string, nodeName types.NodeName, expectedState volumeState) error {
 	var (
-		err            error
-		diskAttached   = true
-		detachTimeout  = 5 * time.Minute
-		detachPollTime = 10 * time.Second
+		err          error
+		diskAttached bool
+		currentState volumeState
+		timeout      = 6 * time.Minute
+		pollTime     = 10 * time.Second
 	)
-	if vsp == nil {
-		vsp, err = vsphere.GetVSphere()
-		if err != nil {
-			return err
-		}
-	}
-	err = wait.Poll(detachPollTime, detachTimeout, func() (bool, error) {
+	err = wait.Poll(pollTime, timeout, func() (bool, error) {
 		diskAttached, err = verifyVSphereDiskAttached(vsp, volumePath, nodeName)
 		if err != nil {
 			return true, err
 		}
-		if !diskAttached {
-			framework.Logf("Volume %q appears to have successfully detached from %q.",
-				volumePath, nodeName)
+
+		if diskAttached {
+			currentState = volumeStateAttached
+		} else {
+			currentState = volumeStateDetached
+		}
+
+		if currentState == expectedState {
+			if expectedState == volumeStateDetached {
+				framework.Logf("Volume %q has successfully detached from %q.", volumePath, nodeName)
+			} else {
+				framework.Logf("Volume %q has successfully attached to %q.", volumePath, nodeName)
+			}
 			return true, nil
 		}
-		framework.Logf("Waiting for Volume %q to detach from %q.", volumePath, nodeName)
+
+		if expectedState == volumeStateDetached {
+			framework.Logf("Waiting for Volume %q to detach from %q.", volumePath, nodeName)
+		} else {
+			framework.Logf("Waiting for Volume %q to attach to %q.", volumePath, nodeName)
+		}
 		return false, nil
 	})
+
 	if err != nil {
 		return err
 	}
-	if diskAttached {
-		return fmt.Errorf("Gave up waiting for Volume %q to detach from %q after %v", volumePath, nodeName, detachTimeout)
+
+	if currentState != expectedState {
+		if expectedState == volumeStateDetached {
+			err = fmt.Errorf("Gave up waiting for Volume %q to detach from %q after %v", volumePath, nodeName, timeout)
+		} else {
+			err = fmt.Errorf("Gave up waiting for Volume %q to attach to %q after %v", volumePath, nodeName, timeout)
+		}
 	}
-	return nil
+	return err
+}
+
+// Wait until vsphere vmdk is attached from the given node or time out after 6 minutes
+func waitForVSphereDiskToAttach(vsp *vsphere.VSphere, volumePath string, nodeName types.NodeName) error {
+	return waitForVSphereDiskStatus(vsp, volumePath, nodeName, volumeStateAttached)
+}
+
+// Wait until vsphere vmdk is detached from the given node or time out after 6 minutes
+func waitForVSphereDiskToDetach(vsp *vsphere.VSphere, volumePath string, nodeName types.NodeName) error {
+	return waitForVSphereDiskStatus(vsp, volumePath, nodeName, volumeStateDetached)
 }
 
 // function to create vsphere volume spec with given VMDK volume path, Reclaim Policy and labels

--- a/test/e2e/storage/vsphere_volume_node_poweroff.go
+++ b/test/e2e/storage/vsphere_volume_node_poweroff.go
@@ -1,0 +1,191 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storage
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/vmware/govmomi/find"
+	"golang.org/x/net/context"
+
+	vimtypes "github.com/vmware/govmomi/vim25/types"
+	"k8s.io/api/core/v1"
+	extensions "k8s.io/api/extensions/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	clientset "k8s.io/client-go/kubernetes"
+	vsphere "k8s.io/kubernetes/pkg/cloudprovider/providers/vsphere"
+	"k8s.io/kubernetes/test/e2e/framework"
+)
+
+/*
+	Test to verify volume status after node power off:
+	1. Verify the pod got provisioned on a different node with volume attached to it
+	2. Verify the volume is detached from the powered off node
+*/
+var _ = SIGDescribe("Node Poweroff [Feature:vsphere] [Slow] [Disruptive]", func() {
+	f := framework.NewDefaultFramework("node-poweroff")
+	var (
+		client     clientset.Interface
+		namespace  string
+		vsp        *vsphere.VSphere
+		workingDir string
+		err        error
+	)
+
+	BeforeEach(func() {
+		framework.SkipUnlessProviderIs("vsphere")
+		client = f.ClientSet
+		namespace = f.Namespace.Name
+		framework.ExpectNoError(framework.WaitForAllNodesSchedulable(client, framework.TestContext.NodeSchedulableTimeout))
+		nodeList := framework.GetReadySchedulableNodesOrDie(f.ClientSet)
+		Expect(nodeList.Items).NotTo(BeEmpty(), "Unable to find ready and schedulable Node")
+		Expect(len(nodeList.Items) > 1).To(BeTrue(), "At least 2 nodes are required for this test")
+		vsp, err = vsphere.GetVSphere()
+		Expect(err).NotTo(HaveOccurred())
+		workingDir = os.Getenv("VSPHERE_WORKING_DIR")
+		Expect(workingDir).NotTo(BeEmpty())
+	})
+
+	/*
+		Steps:
+		1. Create a StorageClass
+		2. Create a PVC with the StorageClass
+		3. Create a Deployment with 1 replica, using the PVC
+		4. Verify the pod got provisioned on a node
+		5. Verify the volume is attached to the node
+		6. Power off the node where pod got provisioned
+		7. Verify the pod got provisioned on a different node
+		8. Verify the volume is attached to the new node
+		9. Verify the volume is detached from the old node
+		10. Delete the Deployment and wait for the volume to be detached
+		11. Delete the PVC
+		12. Delete the StorageClass
+	*/
+	It("verify volume status after node power off", func() {
+		By("Creating a Storage Class")
+		storageClassSpec := getVSphereStorageClassSpec("test-sc", nil)
+		storageclass, err := client.StorageV1().StorageClasses().Create(storageClassSpec)
+		Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Failed to create storage class with err: %v", err))
+		defer client.StorageV1().StorageClasses().Delete(storageclass.Name, nil)
+
+		By("Creating PVC using the Storage Class")
+		pvclaimSpec := getVSphereClaimSpecWithStorageClassAnnotation(namespace, "1Gi", storageclass)
+		pvclaim, err := framework.CreatePVC(client, namespace, pvclaimSpec)
+		Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Failed to create PVC with err: %v", err))
+		defer framework.DeletePersistentVolumeClaim(client, pvclaim.Name, namespace)
+
+		By("Waiting for PVC to be in bound phase")
+		pvclaims := []*v1.PersistentVolumeClaim{pvclaim}
+		pvs, err := framework.WaitForPVClaimBoundPhase(client, pvclaims, framework.ClaimProvisionTimeout)
+		Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Failed to wait until PVC phase set to bound: %v", err))
+		volumePath := pvs[0].Spec.VsphereVolume.VolumePath
+
+		By("Creating a Deployment")
+		deployment, err := framework.CreateDeployment(client, int32(1), map[string]string{"test": "app"}, namespace, pvclaims, "")
+		Expect(framework.WaitForDeploymentCompletes(client, deployment)).NotTo(HaveOccurred())
+		defer client.Extensions().Deployments(namespace).Delete(deployment.Name, &metav1.DeleteOptions{})
+
+		By("Get pod from the deployement")
+		podList, err := framework.GetPodsForDeployment(client, deployment)
+		Expect(podList.Items).NotTo(BeEmpty())
+		pod := podList.Items[0]
+		node1 := types.NodeName(pod.Spec.NodeName)
+
+		By(fmt.Sprintf("Verify disk is attached to the node: %v", node1))
+		isAttached, err := verifyVSphereDiskAttached(vsp, volumePath, node1)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(isAttached).To(BeTrue(), "Disk is not attached to the node")
+
+		By(fmt.Sprintf("Power off the node: %v", node1))
+		govMoMiClient, err := vsphere.GetgovmomiClient(nil)
+		Expect(err).NotTo(HaveOccurred())
+
+		f := find.NewFinder(govMoMiClient.Client, true)
+		ctx, _ := context.WithCancel(context.Background())
+
+		vmPath := workingDir + string(node1)
+		vm, err := f.VirtualMachine(ctx, vmPath)
+		Expect(err).NotTo(HaveOccurred())
+
+		_, err = vm.PowerOff(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		defer vm.PowerOn(ctx)
+
+		err = vm.WaitForPowerState(ctx, vimtypes.VirtualMachinePowerStatePoweredOff)
+		Expect(err).NotTo(HaveOccurred(), "Unable to power off the node")
+
+		// Waiting for the pod to be failed over to a different node
+		node2, err := waitForPodToFailover(client, deployment, node1)
+		Expect(err).NotTo(HaveOccurred(), "Pod did not fail over to a different node")
+
+		By(fmt.Sprintf("Waiting for disk to be attached to the new node: %v", node2))
+		err = waitForVSphereDiskToAttach(vsp, volumePath, node2)
+		Expect(err).NotTo(HaveOccurred(), "Disk is not attached to the node")
+
+		By(fmt.Sprintf("Waiting for disk to be detached from the previous node: %v", node1))
+		err = waitForVSphereDiskToDetach(vsp, volumePath, node1)
+		Expect(err).NotTo(HaveOccurred(), "Disk is not detached from the node")
+
+		By(fmt.Sprintf("Power on the previous node: %v", node1))
+		vm.PowerOn(ctx)
+		err = vm.WaitForPowerState(ctx, vimtypes.VirtualMachinePowerStatePoweredOn)
+		Expect(err).NotTo(HaveOccurred(), "Unable to power on the node")
+	})
+})
+
+// Wait until the pod failed over to a different node, or time out after 3 minutes
+func waitForPodToFailover(client clientset.Interface, deployment *extensions.Deployment, oldNode types.NodeName) (types.NodeName, error) {
+	var (
+		err      error
+		newNode  types.NodeName
+		timeout  = 3 * time.Minute
+		pollTime = 10 * time.Second
+	)
+
+	err = wait.Poll(pollTime, timeout, func() (bool, error) {
+		newNode, err = getNodeForDeployment(client, deployment)
+		if err != nil {
+			return true, err
+		}
+
+		if newNode != oldNode {
+			framework.Logf("The pod has been failed over from %q to %q", oldNode, newNode)
+			return true, nil
+		}
+
+		framework.Logf("Waiting for pod to be failed over from %q", oldNode)
+		return false, nil
+	})
+
+	if err != nil {
+		framework.Logf("Pod did not fail over from %q with error: %v", oldNode, err)
+		return "", err
+	}
+
+	return getNodeForDeployment(client, deployment)
+}
+
+func getNodeForDeployment(client clientset.Interface, deployment *extensions.Deployment) (types.NodeName, error) {
+	podList, err := framework.GetPodsForDeployment(client, deployment)
+	if err != nil {
+		return "", err
+	}
+	return types.NodeName(podList.Items[0].Spec.NodeName), nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds test to verify volume status after the node where the pod got provisioned being powered off and failed over to a different node.

**Which issue this PR fixes**
Fixes https://github.com/vmware/kubernetes/issues/272 and https://github.com/vmware/kubernetes/issues/326

**Special notes for your reviewer**:
This PR includes the following changes:
1. Implement new e2e test for node poweroff / failover scenario
2. Add new utility functions to support k8s Deployment operations
3. Improve existing utility functions to handle new test scenarios

Testing logs:
```
shchen-m02:kubernetes shchen$ go run hack/e2e.go --check-version-skew=false --v --test --test_args='--ginkgo.focus=Node\sPoweroff'
flag provided but not defined: -check-version-skew
Usage of /var/folders/19/tq02vnxs0yz5lcdrxlkg5bwr01yw89/T/go-build538027512/command-line-arguments/_obj/exe/e2e:
  -get
    	go get -u kubetest if old or not installed (default true)
  -old duration
    	Consider kubetest old if it exceeds this (default 24h0m0s)
2017/10/20 13:03:49 e2e.go:55: NOTICE: go run hack/e2e.go is now a shim for test-infra/kubetest
2017/10/20 13:03:49 e2e.go:56:   Usage: go run hack/e2e.go [--get=true] [--old=24h0m0s] -- [KUBETEST_ARGS]
2017/10/20 13:03:49 e2e.go:57:   The separator is required to use --get or --old flags
2017/10/20 13:03:49 e2e.go:58:   The -- flag separator also suppresses this message
2017/10/20 13:03:49 e2e.go:151: The kubetest binary is older than 24h0m0s.
2017/10/20 13:03:49 e2e.go:156: Updating kubetest binary...
2017/10/20 13:03:52 e2e.go:77: Calling kubetest --check-version-skew=false --v --test --test_args=--ginkgo.focus=Node\sPoweroff...
2017/10/20 13:03:52 util.go:154: Running: ./cluster/kubectl.sh --match-server-version=false version
2017/10/20 13:03:53 util.go:156: Step './cluster/kubectl.sh --match-server-version=false version' finished in 707.812289ms
2017/10/20 13:03:53 util.go:154: Running: ./hack/e2e-internal/e2e-status.sh
Skeleton Provider: prepare-e2e not implemented
Client Version: version.Info{Major:"1", Minor:"6+", GitVersion:"v1.6.0-alpha.0.17392+b79c2558691f53-dirty", GitCommit:"b79c2558691f53a6eba5892f8102db76ca12ea79", GitTreeState:"dirty", BuildDate:"2017-10-19T23:00:58Z", GoVersion:"go1.9.1", Compiler:"gc", Platform:"darwin/amd64"}
Server Version: version.Info{Major:"1", Minor:"9+", GitVersion:"v1.9.0-alpha.1.1437+ba66fcb63de9e9", GitCommit:"ba66fcb63de9e9b72e2ccf8b823df33a22df0522", GitTreeState:"clean", BuildDate:"2017-10-20T07:16:05Z", GoVersion:"go1.9.1", Compiler:"gc", Platform:"linux/amd64"}
2017/10/20 13:03:53 util.go:156: Step './hack/e2e-internal/e2e-status.sh' finished in 138.238361ms
2017/10/20 13:03:53 util.go:154: Running: ./hack/ginkgo-e2e.sh --ginkgo.focus=Node\sPoweroff
Conformance test: not doing test setup.
Oct 20 13:03:54.168: INFO: Overriding default scale value of zero to 1
Oct 20 13:03:54.168: INFO: Overriding default milliseconds value of zero to 5000
I1020 13:03:54.267476   75463 e2e.go:383] Starting e2e run "cc6ee617-b5d1-11e7-96db-784f4372ffe4" on Ginkgo node 1
Running Suite: Kubernetes e2e suite
===================================
Random Seed: 1508529833 - Will randomize all specs
Will run 1 of 706 specs

Oct 20 13:03:54.284: INFO: >>> kubeConfig: /Users/shchen/.kube/config
Oct 20 13:03:54.296: INFO: Waiting up to 4h0m0s for all (but 0) nodes to be schedulable
Oct 20 13:03:54.910: INFO: Waiting up to 10m0s for all pods (need at least 0) in namespace 'kube-system' to be running and ready
Oct 20 13:03:55.432: INFO: 13 / 13 pods in namespace 'kube-system' are running and ready (0 seconds elapsed)
Oct 20 13:03:55.432: INFO: expected 4 pod replicas in namespace 'kube-system', 4 are Running and Ready.
Oct 20 13:03:55.523: INFO: Waiting for pods to enter Success, but no pods in "kube-system" match label map[name:e2e-image-puller]
Oct 20 13:03:55.523: INFO: Dumping network health container logs from all nodes...
Oct 20 13:03:55.603: INFO: Client version: v1.6.0-alpha.0.17392+b79c2558691f53-dirty
Oct 20 13:03:55.901: INFO: Server version: v1.9.0-alpha.1.1437+ba66fcb63de9e9
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
------------------------------
[sig-storage] Node Poweroff [Feature:vsphere] 
  verify volume status after node power off
  /Users/shchen/workspace/src/github.com/vmware/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/storage/vsphere_volume_node_poweroff.go:75
[BeforeEach] [sig-storage] Node Poweroff [Feature:vsphere]
  /Users/shchen/workspace/src/github.com/vmware/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
STEP: Creating a kubernetes client
Oct 20 13:03:55.903: INFO: >>> kubeConfig: /Users/shchen/.kube/config
STEP: Building a namespace api object
STEP: Waiting for a default service account to be provisioned in namespace
[BeforeEach] [sig-storage] Node Poweroff [Feature:vsphere]
  /Users/shchen/workspace/src/github.com/vmware/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/storage/vsphere_volume_node_poweroff.go:51
Oct 20 13:03:56.241: INFO: Waiting up to 4h0m0s for all (but 0) nodes to be schedulable
[It] verify volume status after node power off
  /Users/shchen/workspace/src/github.com/vmware/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/storage/vsphere_volume_node_poweroff.go:75
STEP: Creating a Storage Class
STEP: Creating PVC using the Storage Class
STEP: Waiting for PVC to be in bound phase
Oct 20 13:03:57.138: INFO: Waiting up to 5m0s for PersistentVolumeClaim pvc-ldbbp to have phase Bound
Oct 20 13:03:57.221: INFO: PersistentVolumeClaim pvc-ldbbp found but phase is Pending instead of Bound.
Oct 20 13:03:59.306: INFO: PersistentVolumeClaim pvc-ldbbp found and phase=Bound (2.168000156s)
STEP: Creating a Deployment
I1020 13:03:59.637574   75463 deployment_util.go:302] Waiting deployment "deployment-cfa7366c-b5d1-11e7-96db-784f4372ffe4" to complete
Oct 20 13:04:01.818: INFO: deployment status: v1beta1.DeploymentStatus{ObservedGeneration:1, Replicas:1, UpdatedReplicas:1, ReadyReplicas:0, AvailableReplicas:0, UnavailableReplicas:1, Conditions:[]v1beta1.DeploymentCondition{v1beta1.DeploymentCondition{Type:"Available", Status:"True", LastUpdateTime:v1.Time{Time:time.Time{wall:0x0, ext:63644126676, loc:(*time.Location)(0x66c4360)}}, LastTransitionTime:v1.Time{Time:time.Time{wall:0x0, ext:63644126676, loc:(*time.Location)(0x66c4360)}}, Reason:"MinimumReplicasAvailable", Message:"Deployment has minimum availability."}}, CollisionCount:(*int32)(nil)}
Oct 20 13:04:03.805: INFO: deployment status: v1beta1.DeploymentStatus{ObservedGeneration:1, Replicas:1, UpdatedReplicas:1, ReadyReplicas:0, AvailableReplicas:0, UnavailableReplicas:1, Conditions:[]v1beta1.DeploymentCondition{v1beta1.DeploymentCondition{Type:"Available", Status:"True", LastUpdateTime:v1.Time{Time:time.Time{wall:0x0, ext:63644126676, loc:(*time.Location)(0x66c4360)}}, LastTransitionTime:v1.Time{Time:time.Time{wall:0x0, ext:63644126676, loc:(*time.Location)(0x66c4360)}}, Reason:"MinimumReplicasAvailable", Message:"Deployment has minimum availability."}}, CollisionCount:(*int32)(nil)}
Oct 20 13:04:05.958: INFO: deployment status: v1beta1.DeploymentStatus{ObservedGeneration:1, Replicas:1, UpdatedReplicas:1, ReadyReplicas:0, AvailableReplicas:0, UnavailableReplicas:1, Conditions:[]v1beta1.DeploymentCondition{v1beta1.DeploymentCondition{Type:"Available", Status:"True", LastUpdateTime:v1.Time{Time:time.Time{wall:0x0, ext:63644126676, loc:(*time.Location)(0x66c4360)}}, LastTransitionTime:v1.Time{Time:time.Time{wall:0x0, ext:63644126676, loc:(*time.Location)(0x66c4360)}}, Reason:"MinimumReplicasAvailable", Message:"Deployment has minimum availability."}}, CollisionCount:(*int32)(nil)}
Oct 20 13:04:07.825: INFO: deployment status: v1beta1.DeploymentStatus{ObservedGeneration:1, Replicas:1, UpdatedReplicas:1, ReadyReplicas:0, AvailableReplicas:0, UnavailableReplicas:1, Conditions:[]v1beta1.DeploymentCondition{v1beta1.DeploymentCondition{Type:"Available", Status:"True", LastUpdateTime:v1.Time{Time:time.Time{wall:0x0, ext:63644126676, loc:(*time.Location)(0x66c4360)}}, LastTransitionTime:v1.Time{Time:time.Time{wall:0x0, ext:63644126676, loc:(*time.Location)(0x66c4360)}}, Reason:"MinimumReplicasAvailable", Message:"Deployment has minimum availability."}}, CollisionCount:(*int32)(nil)}
Oct 20 13:04:09.796: INFO: deployment status: v1beta1.DeploymentStatus{ObservedGeneration:1, Replicas:1, UpdatedReplicas:1, ReadyReplicas:0, AvailableReplicas:0, UnavailableReplicas:1, Conditions:[]v1beta1.DeploymentCondition{v1beta1.DeploymentCondition{Type:"Available", Status:"True", LastUpdateTime:v1.Time{Time:time.Time{wall:0x0, ext:63644126676, loc:(*time.Location)(0x66c4360)}}, LastTransitionTime:v1.Time{Time:time.Time{wall:0x0, ext:63644126676, loc:(*time.Location)(0x66c4360)}}, Reason:"MinimumReplicasAvailable", Message:"Deployment has minimum availability."}}, CollisionCount:(*int32)(nil)}
Oct 20 13:04:11.803: INFO: deployment status: v1beta1.DeploymentStatus{ObservedGeneration:1, Replicas:1, UpdatedReplicas:1, ReadyReplicas:0, AvailableReplicas:0, UnavailableReplicas:1, Conditions:[]v1beta1.DeploymentCondition{v1beta1.DeploymentCondition{Type:"Available", Status:"True", LastUpdateTime:v1.Time{Time:time.Time{wall:0x0, ext:63644126676, loc:(*time.Location)(0x66c4360)}}, LastTransitionTime:v1.Time{Time:time.Time{wall:0x0, ext:63644126676, loc:(*time.Location)(0x66c4360)}}, Reason:"MinimumReplicasAvailable", Message:"Deployment has minimum availability."}}, CollisionCount:(*int32)(nil)}
STEP: Get pod from the deployement
STEP: Waiting for disk to be attached to the node: kubernetes-node4
Oct 20 13:04:25.051: INFO: Volume "[vsanDatastore] 1874c359-f300-a0cc-fd7e-02002a623c85/kubernetes-dynamic-pvc-e3f33460-b5d1-11e7-9449-0050569c756c.vmdk" has successfully attached to "kubernetes-node4".
STEP: Power off the node: kubernetes-node4
Oct 20 13:04:37.989: INFO: Waiting for pod to be failed over from "kubernetes-node4"
Oct 20 13:04:47.991: INFO: Waiting for pod to be failed over from "kubernetes-node4"
Oct 20 13:04:58.008: INFO: Waiting for pod to be failed over from "kubernetes-node4"
Oct 20 13:05:07.996: INFO: Waiting for pod to be failed over from "kubernetes-node4"
Oct 20 13:05:17.989: INFO: Waiting for pod to be failed over from "kubernetes-node4"
Oct 20 13:05:28.015: INFO: The pod has been failed over from "kubernetes-node4" to "kubernetes-node1"
STEP: Waiting for disk to be attached to the new node: kubernetes-node1
Oct 20 13:05:39.286: INFO: Volume "[vsanDatastore] 1874c359-f300-a0cc-fd7e-02002a623c85/kubernetes-dynamic-pvc-e3f33460-b5d1-11e7-9449-0050569c756c.vmdk" has successfully attached to "kubernetes-node1".
STEP: Waiting for disk to be detached from the previous node: kubernetes-node4
Oct 20 13:05:50.735: INFO: Waiting for Volume "[vsanDatastore] 1874c359-f300-a0cc-fd7e-02002a623c85/kubernetes-dynamic-pvc-e3f33460-b5d1-11e7-9449-0050569c756c.vmdk" to detach from "kubernetes-node4".
Oct 20 13:06:00.629: INFO: Waiting for Volume "[vsanDatastore] 1874c359-f300-a0cc-fd7e-02002a623c85/kubernetes-dynamic-pvc-e3f33460-b5d1-11e7-9449-0050569c756c.vmdk" to detach from "kubernetes-node4".
Oct 20 13:06:10.546: INFO: Waiting for Volume "[vsanDatastore] 1874c359-f300-a0cc-fd7e-02002a623c85/kubernetes-dynamic-pvc-e3f33460-b5d1-11e7-9449-0050569c756c.vmdk" to detach from "kubernetes-node4".
Oct 20 13:06:20.581: INFO: Waiting for Volume "[vsanDatastore] 1874c359-f300-a0cc-fd7e-02002a623c85/kubernetes-dynamic-pvc-e3f33460-b5d1-11e7-9449-0050569c756c.vmdk" to detach from "kubernetes-node4".
Oct 20 13:06:30.518: INFO: Waiting for Volume "[vsanDatastore] 1874c359-f300-a0cc-fd7e-02002a623c85/kubernetes-dynamic-pvc-e3f33460-b5d1-11e7-9449-0050569c756c.vmdk" to detach from "kubernetes-node4".
Oct 20 13:06:40.591: INFO: Waiting for Volume "[vsanDatastore] 1874c359-f300-a0cc-fd7e-02002a623c85/kubernetes-dynamic-pvc-e3f33460-b5d1-11e7-9449-0050569c756c.vmdk" to detach from "kubernetes-node4".
Oct 20 13:06:50.439: INFO: Waiting for Volume "[vsanDatastore] 1874c359-f300-a0cc-fd7e-02002a623c85/kubernetes-dynamic-pvc-e3f33460-b5d1-11e7-9449-0050569c756c.vmdk" to detach from "kubernetes-node4".
Oct 20 13:07:00.425: INFO: Waiting for Volume "[vsanDatastore] 1874c359-f300-a0cc-fd7e-02002a623c85/kubernetes-dynamic-pvc-e3f33460-b5d1-11e7-9449-0050569c756c.vmdk" to detach from "kubernetes-node4".
Oct 20 13:07:10.406: INFO: Waiting for Volume "[vsanDatastore] 1874c359-f300-a0cc-fd7e-02002a623c85/kubernetes-dynamic-pvc-e3f33460-b5d1-11e7-9449-0050569c756c.vmdk" to detach from "kubernetes-node4".
Oct 20 13:07:20.406: INFO: Waiting for Volume "[vsanDatastore] 1874c359-f300-a0cc-fd7e-02002a623c85/kubernetes-dynamic-pvc-e3f33460-b5d1-11e7-9449-0050569c756c.vmdk" to detach from "kubernetes-node4".
Oct 20 13:07:30.363: INFO: Waiting for Volume "[vsanDatastore] 1874c359-f300-a0cc-fd7e-02002a623c85/kubernetes-dynamic-pvc-e3f33460-b5d1-11e7-9449-0050569c756c.vmdk" to detach from "kubernetes-node4".
Oct 20 13:07:40.481: INFO: Waiting for Volume "[vsanDatastore] 1874c359-f300-a0cc-fd7e-02002a623c85/kubernetes-dynamic-pvc-e3f33460-b5d1-11e7-9449-0050569c756c.vmdk" to detach from "kubernetes-node4".
Oct 20 13:07:50.410: INFO: Waiting for Volume "[vsanDatastore] 1874c359-f300-a0cc-fd7e-02002a623c85/kubernetes-dynamic-pvc-e3f33460-b5d1-11e7-9449-0050569c756c.vmdk" to detach from "kubernetes-node4".
Oct 20 13:08:00.337: INFO: Waiting for Volume "[vsanDatastore] 1874c359-f300-a0cc-fd7e-02002a623c85/kubernetes-dynamic-pvc-e3f33460-b5d1-11e7-9449-0050569c756c.vmdk" to detach from "kubernetes-node4".
Oct 20 13:08:10.356: INFO: Waiting for Volume "[vsanDatastore] 1874c359-f300-a0cc-fd7e-02002a623c85/kubernetes-dynamic-pvc-e3f33460-b5d1-11e7-9449-0050569c756c.vmdk" to detach from "kubernetes-node4".
Oct 20 13:08:20.489: INFO: Waiting for Volume "[vsanDatastore] 1874c359-f300-a0cc-fd7e-02002a623c85/kubernetes-dynamic-pvc-e3f33460-b5d1-11e7-9449-0050569c756c.vmdk" to detach from "kubernetes-node4".
Oct 20 13:08:30.379: INFO: Waiting for Volume "[vsanDatastore] 1874c359-f300-a0cc-fd7e-02002a623c85/kubernetes-dynamic-pvc-e3f33460-b5d1-11e7-9449-0050569c756c.vmdk" to detach from "kubernetes-node4".
Oct 20 13:08:40.350: INFO: Waiting for Volume "[vsanDatastore] 1874c359-f300-a0cc-fd7e-02002a623c85/kubernetes-dynamic-pvc-e3f33460-b5d1-11e7-9449-0050569c756c.vmdk" to detach from "kubernetes-node4".
Oct 20 13:08:50.425: INFO: Waiting for Volume "[vsanDatastore] 1874c359-f300-a0cc-fd7e-02002a623c85/kubernetes-dynamic-pvc-e3f33460-b5d1-11e7-9449-0050569c756c.vmdk" to detach from "kubernetes-node4".
Oct 20 13:09:00.422: INFO: Waiting for Volume "[vsanDatastore] 1874c359-f300-a0cc-fd7e-02002a623c85/kubernetes-dynamic-pvc-e3f33460-b5d1-11e7-9449-0050569c756c.vmdk" to detach from "kubernetes-node4".
Oct 20 13:09:10.402: INFO: Waiting for Volume "[vsanDatastore] 1874c359-f300-a0cc-fd7e-02002a623c85/kubernetes-dynamic-pvc-e3f33460-b5d1-11e7-9449-0050569c756c.vmdk" to detach from "kubernetes-node4".
Oct 20 13:09:20.404: INFO: Waiting for Volume "[vsanDatastore] 1874c359-f300-a0cc-fd7e-02002a623c85/kubernetes-dynamic-pvc-e3f33460-b5d1-11e7-9449-0050569c756c.vmdk" to detach from "kubernetes-node4".
Oct 20 13:09:30.402: INFO: Waiting for Volume "[vsanDatastore] 1874c359-f300-a0cc-fd7e-02002a623c85/kubernetes-dynamic-pvc-e3f33460-b5d1-11e7-9449-0050569c756c.vmdk" to detach from "kubernetes-node4".
Oct 20 13:09:40.400: INFO: Waiting for Volume "[vsanDatastore] 1874c359-f300-a0cc-fd7e-02002a623c85/kubernetes-dynamic-pvc-e3f33460-b5d1-11e7-9449-0050569c756c.vmdk" to detach from "kubernetes-node4".
Oct 20 13:09:50.425: INFO: Waiting for Volume "[vsanDatastore] 1874c359-f300-a0cc-fd7e-02002a623c85/kubernetes-dynamic-pvc-e3f33460-b5d1-11e7-9449-0050569c756c.vmdk" to detach from "kubernetes-node4".
Oct 20 13:10:00.334: INFO: Waiting for Volume "[vsanDatastore] 1874c359-f300-a0cc-fd7e-02002a623c85/kubernetes-dynamic-pvc-e3f33460-b5d1-11e7-9449-0050569c756c.vmdk" to detach from "kubernetes-node4".
Oct 20 13:10:10.394: INFO: Waiting for Volume "[vsanDatastore] 1874c359-f300-a0cc-fd7e-02002a623c85/kubernetes-dynamic-pvc-e3f33460-b5d1-11e7-9449-0050569c756c.vmdk" to detach from "kubernetes-node4".
Oct 20 13:10:20.385: INFO: Waiting for Volume "[vsanDatastore] 1874c359-f300-a0cc-fd7e-02002a623c85/kubernetes-dynamic-pvc-e3f33460-b5d1-11e7-9449-0050569c756c.vmdk" to detach from "kubernetes-node4".
Oct 20 13:10:30.427: INFO: Waiting for Volume "[vsanDatastore] 1874c359-f300-a0cc-fd7e-02002a623c85/kubernetes-dynamic-pvc-e3f33460-b5d1-11e7-9449-0050569c756c.vmdk" to detach from "kubernetes-node4".
Oct 20 13:10:40.362: INFO: Waiting for Volume "[vsanDatastore] 1874c359-f300-a0cc-fd7e-02002a623c85/kubernetes-dynamic-pvc-e3f33460-b5d1-11e7-9449-0050569c756c.vmdk" to detach from "kubernetes-node4".
Oct 20 13:10:50.379: INFO: Waiting for Volume "[vsanDatastore] 1874c359-f300-a0cc-fd7e-02002a623c85/kubernetes-dynamic-pvc-e3f33460-b5d1-11e7-9449-0050569c756c.vmdk" to detach from "kubernetes-node4".
Oct 20 13:11:00.412: INFO: Waiting for Volume "[vsanDatastore] 1874c359-f300-a0cc-fd7e-02002a623c85/kubernetes-dynamic-pvc-e3f33460-b5d1-11e7-9449-0050569c756c.vmdk" to detach from "kubernetes-node4".
Oct 20 13:11:10.390: INFO: Waiting for Volume "[vsanDatastore] 1874c359-f300-a0cc-fd7e-02002a623c85/kubernetes-dynamic-pvc-e3f33460-b5d1-11e7-9449-0050569c756c.vmdk" to detach from "kubernetes-node4".
Oct 20 13:11:20.472: INFO: Waiting for Volume "[vsanDatastore] 1874c359-f300-a0cc-fd7e-02002a623c85/kubernetes-dynamic-pvc-e3f33460-b5d1-11e7-9449-0050569c756c.vmdk" to detach from "kubernetes-node4".
Oct 20 13:11:30.392: INFO: Volume "[vsanDatastore] 1874c359-f300-a0cc-fd7e-02002a623c85/kubernetes-dynamic-pvc-e3f33460-b5d1-11e7-9449-0050569c756c.vmdk" has successfully detached from "kubernetes-node4".
STEP: Power on the previous node: kubernetes-node4
Oct 20 13:11:32.499: INFO: Deleting PersistentVolumeClaim "pvc-ldbbp"
[AfterEach] [sig-storage] Node Poweroff [Feature:vsphere]
  /Users/shchen/workspace/src/github.com/vmware/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
Oct 20 13:11:32.711: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
STEP: Destroying namespace "e2e-tests-node-poweroff-cr7ht" for this suite.
Oct 20 13:11:44.641: INFO: namespace: e2e-tests-node-poweroff-cr7ht, resource: bindings, ignored listing per whitelist
Oct 20 13:11:45.709: INFO: namespace e2e-tests-node-poweroff-cr7ht deletion completed in 12.906499472s

• [SLOW TEST:469.806 seconds]
[sig-storage] Node Poweroff [Feature:vsphere]
/Users/shchen/workspace/src/github.com/vmware/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/storage/framework.go:22
  verify volume status after node power off
  /Users/shchen/workspace/src/github.com/vmware/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/storage/vsphere_volume_node_poweroff.go:75
------------------------------
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSOct 20 13:11:45.717: INFO: Running AfterSuite actions on all node
Oct 20 13:11:45.717: INFO: Running AfterSuite actions on node 1

Ran 1 of 706 Specs in 471.433 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 705 Skipped PASS

Ginkgo ran 1 suite in 7m51.990217772s
Test Suite Passed
2017/10/20 13:11:45 util.go:156: Step './hack/ginkgo-e2e.sh --ginkgo.focus=Node\sPoweroff' finished in 7m52.435682872s
2017/10/20 13:11:45 e2e.go:81: Done
```

**Release note**: