### PR TITLE
Automating tags and policy creation in VC

### DIFF
--- a/container-image/Dockerfile
+++ b/container-image/Dockerfile
@@ -12,7 +12,7 @@ ENV GOROOT /opt/go
 ENV GOPATH /root/.go
 
 RUN apt-get update
-RUN apt-get install -y openssh-server git make curl uuid-runtime genisoimage net-tools binfmt-support vim expect ssh
+RUN apt-get install -y openssh-server git make curl uuid-runtime genisoimage net-tools binfmt-support vim expect ssh python python-pip unzip
 RUN apt-get clean
 
 RUN cd /opt && wget https://get.docker.com/builds/Linux/x86_64/docker-1.12.6.tgz && \
@@ -29,6 +29,15 @@ RUN go get github.com/vmware/govmomi/govc && \
     ln -s /root/.go/bin/govc /usr/bin
 
 RUN mkdir -p /root/scripts
-ADD configre_passwordless_login.sh /root/scripts/configure_passwordless_login.sh
+ADD configure_passwordless_login.sh /root/scripts/configure_passwordless_login.sh
 ADD copy_pub_key.exp /root/scripts/copy_pub_key.exp
 
+RUN cd /root && wget https://github.com/vmware/vsphere-automation-sdk-python/archive/v6.6.1.zip && \
+    unzip v6.6.1.zip && \
+    cd vsphere-automation-sdk-python-6.6.1 && \
+    pip install -r requirements.txt --extra-index-url file:///root/vsphere-automation-sdk-python-6.6.1/lib/
+
+ADD create_policy.py /root/scripts/create_policy.py
+ADD tagging_workflow.py /root/scripts/tagging_workflow.py
+
+ENV PYTHONPATH=/root/vsphere-automation-sdk-python-6.6.1/

--- a/container-image/create_policy.py
+++ b/container-image/create_policy.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python
+from pyVmomi import vim, pbm, VmomiSupport
+from pyVim.connect import SmartConnect, Disconnect
+
+import atexit
+import argparse
+import ast
+import getpass
+import sys
+import ssl
+
+"""
+Example of using Storage Policy Based Management (SPBM) API
+to update an existing VM Storage Policy.
+
+Required Prviledge: Profile-driven storage update
+
+This program is a modified version of 
+
+https://github.com/vmware/pyvmomi-community-samples/blob/master/samples/update_vm_storage_policy.py
+"""
+
+# retrieve SPBM API endpoint
+def GetPbmConnection(vpxdStub):
+    import Cookie
+    import pyVmomi
+    sessionCookie = vpxdStub.cookie.split('"')[1]
+    httpContext = VmomiSupport.GetHttpContext()
+    cookie = Cookie.SimpleCookie()
+    cookie["vmware_soap_session"] = sessionCookie
+    httpContext["cookies"] = cookie
+    VmomiSupport.GetRequestContext()["vcSessionCookie"] = sessionCookie
+    hostname = vpxdStub.host.split(":")[0]
+    pbmStub = pyVmomi.SoapStubAdapter(
+        host=hostname,
+        version="pbm.version.version1",
+        path="/pbm/sdk",
+        poolSize=0,
+        sslContext=ssl._create_unverified_context())
+    pbmSi = pbm.ServiceInstance("ServiceInstance", pbmStub)
+    pbmContent = pbmSi.RetrieveContent()
+
+    return (pbmSi, pbmContent)
+
+
+# Create required SPBM Capability object from python dict
+def _dictToCapability(d):
+    ciList = []
+
+    for k, v in d.iteritems():
+        namespace = k.split('.')[0]
+        id = constraint_id = k.split('.')[1]
+        pi = pbm.capability.PropertyInstance(
+                                id=constraint_id,
+                                value=v
+        )
+
+        if k.split('.')[0] == 'tag':
+            namespace = 'http://www.vmware.com/storage/tag'
+            constraint_id = 'com.vmware.storage.tag.cluster.property'
+            values = pbm.capability.types.DiscreteSet()
+            values.values.append(v)
+            pi.id = constraint_id
+            pi.value = values
+
+        ciList.append(
+            pbm.capability.CapabilityInstance(
+                id=pbm.capability.CapabilityMetadata.UniqueId(
+                    namespace = namespace,
+                    id=id
+                ),
+                constraint=[
+                    pbm.capability.ConstraintInstance(
+                        propertyInstance=[pi]
+                    )
+                ]
+            )
+        )
+    return ciList
+
+
+# Create VM Storage Policy
+def CreateProfile(pm, rules, name):
+    pm.PbmCreate(
+        createSpec=pbm.profile.CapabilityBasedProfileCreateSpec(
+            description=None,
+            name=name,
+            resourceType=pbm.profile.ResourceType(resourceType="STORAGE"),
+            constraints=pbm.profile.SubProfileCapabilityConstraints(
+                subProfiles=[
+                    pbm.profile.SubProfileCapabilityConstraints.SubProfile(
+                        name="Object",
+                        capability=_dictToCapability(rules)
+                    )
+                ]
+            )
+        )
+    )
+
+
+def GetArgs():
+    """
+    Supports the command-line arguments listed below.
+    """
+    parser = argparse.ArgumentParser(
+        description='Process args for VSAN SDK sample application')
+    parser.add_argument('-s', '--host', required=True, action='store',
+                        help='Remote host to connect to')
+    parser.add_argument('-o', '--port', type=int, default=443, action='store',
+                        help='Port to connect on')
+    parser.add_argument('-u', '--user', required=True, action='store',
+                        help='User name to use when connecting to host')
+    parser.add_argument('-p', '--password', required=False, action='store',
+                        help='Password to use when connecting to host')
+    parser.add_argument('-n', '--policy-name', required=True, action='store',
+                        help='VM Storage Policy ID')
+    parser.add_argument('-r', '--policy-rule', required=True, action='store',
+                        help="VM Storage Policy Rule encoded as dictionary"
+                        "example:"
+                        " \"{\'VSAN.hostFailuresToTolerate\':1,"
+                        "    \'VSAN.stripeWidth\':2,"
+                        "    \'VSAN.forceProvisioning\':False}\"")
+    args = parser.parse_args()
+    return args
+
+
+# Start program
+def main():
+    args = GetArgs()
+    if args.password:
+        password = args.password
+    else:
+        password = getpass.getpass(prompt='Enter password for host %s and '
+                                   'user %s: ' % (args.host, args.user))
+
+    si = SmartConnect(host=args.host,
+                      user=args.user,
+                      pwd=password,
+                      port=int(args.port),
+                      sslContext=ssl._create_unverified_context())
+
+    atexit.register(Disconnect, si)
+
+    # Connect to SPBM Endpoint
+    pbmSi, pbmContent = GetPbmConnection(si._stub)
+
+    pm = pbmContent.profileManager
+    profileIds = pm.PbmQueryProfile(
+        resourceType=pbm.profile.ResourceType(resourceType="STORAGE"),
+        profileCategory="REQUIREMENT"
+    )
+
+    profiles = []
+    if len(profileIds) > 0:
+        profiles = pm.PbmRetrieveContent(profileIds=profileIds)
+
+    # Attempt to find profile name given by user
+    for profile in profiles:
+        if profile.name == args.policy_name:
+            print("Policy with name '%s' already exists" % (args.policy_name))
+            return
+
+    #Convert string to dict
+    vmPolicyRules = ast.literal_eval(args.policy_rule)
+
+    print("Creating VM Storage Policy %s with %s ..." % (
+        args.policy_name, args.policy_rule))
+    CreateProfile(pm, vmPolicyRules, args.policy_name)
+
+
+# Start program
+if __name__ == "__main__":
+    main()

--- a/container-image/tagging_workflow.py
+++ b/container-image/tagging_workflow.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python
+
+"""
+* *******************************************************
+* Copyright (c) VMware, Inc. 2014, 2016. All Rights Reserved.
+* SPDX-License-Identifier: MIT
+* *******************************************************
+*
+* DISCLAIMER. THIS PROGRAM IS PROVIDED TO YOU "AS IS" WITHOUT
+* WARRANTIES OR CONDITIONS OF ANY KIND, WHETHER ORAL OR WRITTEN,
+* EXPRESS OR IMPLIED. THE AUTHOR SPECIFICALLY DISCLAIMS ANY IMPLIED
+* WARRANTIES OR CONDITIONS OF MERCHANTABILITY, SATISFACTORY QUALITY,
+* NON-INFRINGEMENT AND FITNESS FOR A PARTICULAR PURPOSE.
+
+THIS PROGRAM IS A MODIFIED MINIMAL VERSION OF 
+https://github.com/vmware/vsphere-automation-sdk-python/blob/master/samples/vsphere/tagging/tagging_workflow.py
+"""
+
+__author__ = 'VMware, Inc.'
+__copyright__ = 'Copyright 2014, 2016 VMware, Inc. All rights reserved.'
+__vcenter_version__ = '6.0+'
+
+import time
+
+from com.vmware.cis.tagging_client import (
+    Category, CategoryModel, Tag, TagAssociation)
+from com.vmware.vapi.std_client import DynamicID
+
+import samples
+
+from samples.vsphere.common.sample_base import SampleBase
+from samples.vsphere.common.vim.helpers.get_datastore_by_name import get_datastore_id
+
+
+class TaggingWorkflow(SampleBase):
+    """
+    Demonstrates tagging CRUD operations
+    Step 1: Create a Tag category.
+    Step 2: Create a Tag under the category.
+    Step 3: Retrieve the managed object id of an existing datastore from its name.
+    Step 4: Assign the tag to the datastore.
+    """
+    def __init__(self):
+        SampleBase.__init__(self, self.__doc__)
+        self.servicemanager = None
+
+        self.category_svc = None
+        self.tag_svc = None
+        self.tag_association = None
+
+        self.category_name = None
+        self.category_desc = None
+        self.tag_name = None
+        self.tag_desc = None
+
+        self.datastore_name = None
+        self.datastore_moid = None
+        self.category_id = None
+        self.tag_id = None
+        self.tag_attached = False
+        self.dynamic_id = None
+
+    def _options(self):
+        self.argparser.add_argument('-datastorename', '--datastorename', help='Name of the datastore to be tagged')
+        self.argparser.add_argument('-categoryname', '--categoryname', help='Name of the Category to be created')
+        self.argparser.add_argument('-categorydesc', '--categorydesc', help='Description of the Category to be created')
+        self.argparser.add_argument('-tagname', '--tagname', help='Name of the tag to be created')
+        self.argparser.add_argument('-tagdesc', '--tagdesc', help='Description of the tag to be created')
+
+    def _setup(self):
+        if self.datastore_name is None:  # for testing
+            self.datastore_name = self.args.datastorename
+        assert self.datastore_name is not None
+        print('datastore Name: {0}'.format(self.datastore_name))
+
+        if self.category_name is None:
+            self.category_name = self.args.categoryname
+        assert self.category_name is not None
+        print('Category Name: {0}'.format(self.category_name))
+
+        if self.category_desc is None:
+            self.category_desc = self.args.categorydesc
+        assert self.category_desc is not None
+        print('Category Description: {0}'.format(self.category_desc))
+
+        if self.tag_name is None:
+            self.tag_name = self.args.tagname
+        assert self.tag_name is not None
+        print('Tag Name: {0}'.format(self.tag_name))
+
+        if self.tag_desc is None:
+            self.tag_desc = self.args.tagdesc
+        assert self.tag_desc is not None
+        print('Tag Description: {0}'.format(self.tag_desc))
+
+        if self.servicemanager is None:
+            self.servicemanager = self.get_service_manager()
+
+        # Sample is not failing if datastorename passed is not valid
+        # Validating if datastore Name passed is Valid
+        print('finding the datastore {0}'.format(self.datastore_name))
+        self.datastore_moid = get_datastore_id(service_manager=self.servicemanager, datastore_name=self.datastore_name)
+        assert self.datastore_moid is not None
+        print('Found datastore:{0} mo_id:{1}'.format(self.datastore_name, self.datastore_moid))
+
+        self.category_svc = Category(self.servicemanager.stub_config)
+        self.tag_svc = Tag(self.servicemanager.stub_config)
+        self.tag_association = TagAssociation(self.servicemanager.stub_config)
+
+    def _execute(self):
+        categories = self.category_svc.list()
+        for category in categories:
+            catObj = self.category_svc.get(category)
+            if catObj.name == self.category_name:
+        	print('Found existing category: {0}. Exiting.'.format(catObj.name))
+		return
+
+        tags = self.tag_svc.list()
+        for tag in tags:
+            tagObj = self.tag_svc.get(tag)
+            if tagObj.name == self.tag_name:
+                print('Found existing tag: {0}. Exiting.'.format(tagObj.name))
+                return
+ 
+        print('creating a new tag category...')
+        self.category_id = self.create_tag_category(self.category_name, self.category_desc,
+                                                    CategoryModel.Cardinality.MULTIPLE)
+        assert self.category_id is not None
+        print('Tag category created; Id: {0}'.format(self.category_id))
+
+        print("creating a new Tag...")
+        self.tag_id = self.create_tag(self.tag_name, self.tag_desc, self.category_id)
+        assert self.tag_id is not None
+        print('Tag created; Id: {0}'.format(self.tag_id))
+
+        print('Tagging the datastore {0}...'.format(self.datastore_name))
+        self.dynamic_id = DynamicID(type='Datastore', id=self.datastore_moid)
+        self.tag_association.attach(tag_id=self.tag_id, object_id=self.dynamic_id)
+        for tag_id in self.tag_association.list_attached_tags(self.dynamic_id):
+            if tag_id == self.tag_id:
+                self.tag_attached = True
+                break
+        assert self.tag_attached
+        print('Tagged datastore: {0}'.format(self.datastore_moid))
+
+    def create_tag_category(self, name, description, cardinality):
+        """create a category. User who invokes this needs create category privilege."""
+        create_spec = self.category_svc.CreateSpec()
+        create_spec.name = name
+        create_spec.description = description
+        create_spec.cardinality = cardinality
+        associableTypes = set()
+        create_spec.associable_types = associableTypes
+        return self.category_svc.create(create_spec)
+
+    def create_tag(self, name, description, category_id):
+        """Creates a Tag"""
+        create_spec = self.tag_svc.CreateSpec()
+        create_spec.name = name
+        create_spec.description = description
+        create_spec.category_id = category_id
+        return self.tag_svc.create(create_spec)
+
+def main():
+    tagging_workflow = TaggingWorkflow()
+    tagging_workflow.main()
+
+
+# Start program
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds python scripts to automate creation of tags, categories, tag a datastore and create storage policies
**Which issue this PR fixes** : fixes #276

**Special notes for your reviewer**:
Dockerfile is modified to build the image.
Once the image is built, the python scripts can be used as follows:
```
cd /root/scripts

export DATASTORE_NAME=sharedVmfs-0
export CATEGORY=C1
export TAG=T1
export GOLD_POLICY_RULE="{'VSAN.hostFailuresToTolerate':1}"
export TAG_POLICY_RULE= "{'tag.$CATEGORY':'$TAG'}"

python tagging_workflow.py --server $VC_IP --username $USERNAME  --datastorename $DATASTORE_NAME --categoryname $CATEGORY -categorydesc $CATEGORY --tagname $TAG --tagdesc $TAG -v -p $PASSWORD
python create_policy.py -s $VC_IP -u $USERNAME -r $GOLD_POLICY_RULE -n $VSPHERE_SPBM_GOLD_POLICY -p $PASSWORD
python create_policy.py -s $VC_IP -u $USERNAME -r $TAG_POLICY_RULE -n $VSPHERE_SPBM_GOLD_POLICY -p $PASSWORD
```
**Release note**:

```
None
```
