### PR TITLE
Using ClientBuilder to listen Node events

### DIFF
--- a/pkg/cloudprovider/cloud.go
+++ b/pkg/cloudprovider/cloud.go
@@ -143,10 +143,6 @@ type Instances interface {
 	// InstanceExistsByProviderID returns true if the instance for the given provider id still is running.
 	// If false is returned with no error, the instance will be immediately deleted by the cloud controller manager.
 	InstanceExistsByProviderID(providerID string) (bool, error)
-	// Notification to the cloud provider when node is registered
-	NodeRegistered(nodes *v1.Node)
-	// Notification to the cloud provider when node is unregistered
-	NodeUnregistered(nodes *v1.Node)
 }
 
 // Route is a representation of an advanced routing rule.

--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -999,16 +999,6 @@ func (c *Cloud) HasClusterID() bool {
 	return len(c.tagging.clusterID()) > 0
 }
 
-// Notification handler when node is registered.
-func (c *Cloud) NodeRegistered(node *v1.Node) {
-
-}
-
-// Notification handler when node is unregistered.
-func (c *Cloud) NodeUnregistered(node *v1.Node) {
-
-}
-
 // NodeAddresses is an implementation of Instances.NodeAddresses.
 func (c *Cloud) NodeAddresses(name types.NodeName) ([]v1.NodeAddress, error) {
 	if c.selfAWSInstance.nodeName == name || len(name) == 0 {

--- a/pkg/cloudprovider/providers/azure/azure.go
+++ b/pkg/cloudprovider/providers/azure/azure.go
@@ -24,7 +24,6 @@ import (
 	"io/ioutil"
 	"time"
 
-	"k8s.io/api/core/v1"
 	"k8s.io/client-go/util/flowcontrol"
 	"k8s.io/kubernetes/pkg/cloudprovider"
 	"k8s.io/kubernetes/pkg/controller"
@@ -448,14 +447,4 @@ func initDiskControllers(az *Cloud) error {
 	az.controllerCommon = common
 
 	return nil
-}
-
-// Notification handler when node is registered.
-func (az *Cloud) NodeRegistered(node *v1.Node) {
-
-}
-
-// Notification handler when node is unregistered.
-func (az *Cloud) NodeUnregistered(node *v1.Node) {
-
 }

--- a/pkg/cloudprovider/providers/cloudstack/cloudstack.go
+++ b/pkg/cloudprovider/providers/cloudstack/cloudstack.go
@@ -28,7 +28,6 @@ import (
 	"github.com/xanzy/go-cloudstack/cloudstack"
 	"gopkg.in/gcfg.v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/api/core/v1"
 	"k8s.io/kubernetes/pkg/cloudprovider"
 	"k8s.io/kubernetes/pkg/controller"
 )
@@ -262,14 +261,4 @@ func (cs *CSCloud) GetZoneByNodeName(nodeName types.NodeName) (cloudprovider.Zon
 	zone.Region = instance.Zonename
 
 	return zone, nil
-}
-
-// Notification handler when node is registered.
-func (cs *CSCloud) NodeRegistered(node *v1.Node) {
-
-}
-
-// Notification handler when node is unregistered.
-func (cs *CSCloud) NodeUnregistered(node *v1.Node) {
-
 }

--- a/pkg/cloudprovider/providers/cloudstack/metadata.go
+++ b/pkg/cloudprovider/providers/cloudstack/metadata.go
@@ -209,13 +209,3 @@ func findDHCPServer() (string, error) {
 
 	return "", errors.New("no server found")
 }
-
-// Notification handler when node is registered.
-func (m *metadata) NodeRegistered(node *v1.Node) {
-
-}
-
-// Notification handler when node is unregistered.
-func (m *metadata) NodeUnregistered(node *v1.Node) {
-
-}

--- a/pkg/cloudprovider/providers/fake/fake.go
+++ b/pkg/cloudprovider/providers/fake/fake.go
@@ -330,13 +330,3 @@ func (c *FakeCloud) GetLabelsForVolume(pv *v1.PersistentVolume) (map[string]stri
 	}
 	return nil, fmt.Errorf("label not found for volume")
 }
-
-// Notification handler when node is registered.
-func (f *FakeCloud) NodeRegistered(node *v1.Node) {
-
-}
-
-// Notification handler when node is unregistered.
-func (f *FakeCloud) NodeUnregistered(node *v1.Node) {
-
-}

--- a/pkg/cloudprovider/providers/gce/gce.go
+++ b/pkg/cloudprovider/providers/gce/gce.go
@@ -1147,13 +1147,3 @@ func (manager *GCEServiceManager) getRegionFromZone(zoneInfo zoneType) (string, 
 
 	return region, nil
 }
-
-// Notification handler when node is registered.
-func (gce *GCECloud) NodeRegistered(node *v1.Node) {
-
-}
-
-// Notification handler when node is unregistered.
-func (gce *GCECloud) NodeUnregistered(node *v1.Node) {
-
-}

--- a/pkg/cloudprovider/providers/openstack/openstack_instances.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_instances.go
@@ -199,13 +199,3 @@ func instanceIDFromProviderID(providerID string) (instanceID string, err error) 
 	}
 	return matches[1], nil
 }
-
-// Notification handler when node is registered.
-func (i *Instances) NodeRegistered(node *v1.Node) {
-
-}
-
-// Notification handler when node is unregistered.
-func (i *Instances) NodeUnregistered(node *v1.Node) {
-
-}

--- a/pkg/cloudprovider/providers/ovirt/ovirt.go
+++ b/pkg/cloudprovider/providers/ovirt/ovirt.go
@@ -323,13 +323,3 @@ func (v *OVirtCloud) CurrentNodeName(hostname string) (types.NodeName, error) {
 func (v *OVirtCloud) AddSSHKeyToAllInstances(user string, keyData []byte) error {
 	return errors.New("unimplemented")
 }
-
-// Notification handler when node is registered.
-func (v *OVirtCloud) NodeRegistered(node *v1.Node) {
-
-}
-
-// Notification handler when node is unregistered.
-func (v *OVirtCloud) NodeUnregistered(node *v1.Node) {
-
-}

--- a/pkg/cloudprovider/providers/photon/photon.go
+++ b/pkg/cloudprovider/providers/photon/photon.go
@@ -737,13 +737,3 @@ func (pc *PCCloud) DeleteDisk(pdID string) error {
 
 	return nil
 }
-
-// Notification handler when node is registered.
-func (pc *PCCloud) NodeRegistered(node *v1.Node) {
-
-}
-
-// Notification handler when node is unregistered.
-func (pc *PCCloud) NodeUnregistered(node *v1.Node) {
-
-}

--- a/pkg/cloudprovider/providers/rackspace/rackspace.go
+++ b/pkg/cloudprovider/providers/rackspace/rackspace.go
@@ -784,13 +784,3 @@ func (rs *Rackspace) DisksAreAttached(instanceID string, volumeIDs []string) (ma
 func (rs *Rackspace) ShouldTrustDevicePath() bool {
 	return true
 }
-
-// Notification handler when node is registered.
-func (i *Instances) NodeRegistered(node *v1.Node) {
-
-}
-
-// Notification handler when node is unregistered.
-func (i *Instances) NodeUnregistered(node *v1.Node) {
-
-}

--- a/pkg/cloudprovider/providers/vsphere/vsphere.go
+++ b/pkg/cloudprovider/providers/vsphere/vsphere.go
@@ -35,6 +35,9 @@ import (
 	"golang.org/x/net/context"
 	"k8s.io/api/core/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/tools/cache"
 	v1helper "k8s.io/kubernetes/pkg/api/v1/helper"
 	"k8s.io/kubernetes/pkg/cloudprovider"
 	"k8s.io/kubernetes/pkg/cloudprovider/providers/vsphere/vclib"
@@ -203,7 +206,23 @@ func init() {
 }
 
 // Initialize passes a Kubernetes clientBuilder interface to the cloud provider
-func (vs *VSphere) Initialize(clientBuilder controller.ControllerClientBuilder) {}
+func (vs *VSphere) Initialize(clientBuilder controller.ControllerClientBuilder) {
+	if vs.cfg == nil {
+		return
+	}
+
+	// Only on controller node it is required to register listeners.
+	// Register callbacks for node updates
+	client := clientBuilder.ClientOrDie("vSphere-cloud-provider")
+	factory := informers.NewSharedInformerFactory(client, 5*time.Minute)
+	nodeInformer := factory.Core().V1().Nodes()
+	nodeInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    vs.NodeAdded,
+		DeleteFunc: vs.NodeDeleted,
+	})
+	go nodeInformer.Informer().Run(wait.NeverStop)
+   glog.V(4).Infof("vSphere cloud provider initialized")
+}
 
 // Creates new worker node interface and returns
 func newWorkerNode() (*VSphere, error) {
@@ -368,8 +387,8 @@ func newControllerNode(cfg VSphereConfig) (*VSphere, error) {
 		vsphereInstanceMap: vsphereInstanceMap,
 		nodeManager: &NodeManager{
 			vsphereInstanceMap: vsphereInstanceMap,
-			nodeInfoMap: make(map[string]*NodeInfo),
-			registeredNodes: make(map[string]*v1.Node),
+			nodeInfoMap:        make(map[string]*NodeInfo),
+			registeredNodes:    make(map[string]*v1.Node),
 		},
 		cfg: &cfg,
 	}
@@ -928,14 +947,27 @@ func (vs *VSphere) HasClusterID() bool {
 	return true
 }
 
-// Notification handler when node is registered.
-func (vs *VSphere) NodeRegistered(node *v1.Node) {
-	glog.V(4).Infof("Node Registered: %+v", node)
+// Notification handler when node is added into k8s cluster.
+func (vs *VSphere) NodeAdded(obj interface{}) {
+	node, ok := obj.(*v1.Node)
+	if node == nil || !ok {
+      glog.Warningf("NodeAdded: unrecognized object %+v", obj);
+		return
+	}
+
+	glog.V(4).Infof("Node added: %+v", node)
 	vs.nodeManager.RegisterNode(node)
 }
 
-// Notification handler when node is unregistered.
-func (vs *VSphere) NodeUnregistered(node *v1.Node) {
-	glog.V(4).Infof("Node Unregistered: %+v", node)
+// Notification handler when node is removed from k8s cluster.
+func (vs *VSphere) NodeDeleted(obj interface{}) {
+	node, ok := obj.(*v1.Node)
+	if node == nil || !ok {
+      glog.Warningf("NodeDeleted: unrecognized object %+v", obj);
+		return
+	}
+
+	glog.V(4).Infof("Node deleted: %+v", node)
 	vs.nodeManager.UnRegisterNode(node)
 }
+

--- a/pkg/cloudprovider/providers/vsphere/vsphere_test.go
+++ b/pkg/cloudprovider/providers/vsphere/vsphere_test.go
@@ -39,7 +39,7 @@ func configFromEnv() (cfg VSphereConfig, ok bool) {
 	cfg.Global.Password = os.Getenv("VSPHERE_PASSWORD")
 	cfg.Global.Datacenter = os.Getenv("VSPHERE_DATACENTER")
 	cfg.Network.PublicNetwork = os.Getenv("VSPHERE_PUBLIC_NETWORK")
-	cfg.Global.Datastore = os.Getenv("VSPHERE_DATASTORE")
+	cfg.Global.DefaultDatastore = os.Getenv("VSPHERE_DATASTORE")
 	cfg.Disk.SCSIControllerType = os.Getenv("VSPHERE_SCSICONTROLLER_TYPE")
 	cfg.Global.WorkingDir = os.Getenv("VSPHERE_WORKING_DIR")
 	cfg.Global.VMName = os.Getenv("VSPHERE_VM_NAME")
@@ -103,7 +103,7 @@ func TestNewVSphere(t *testing.T) {
 		t.Skipf("No config found in environment")
 	}
 
-	_, err := newVSphere(cfg)
+	_, err := newControllerNode(cfg)
 	if err != nil {
 		t.Fatalf("Failed to construct/authenticate vSphere: %s", err)
 	}
@@ -116,7 +116,7 @@ func TestVSphereLogin(t *testing.T) {
 	}
 
 	// Create vSphere configuration object
-	vs, err := newVSphere(cfg)
+	vs, err := newControllerNode(cfg)
 	if err != nil {
 		t.Fatalf("Failed to construct/authenticate vSphere: %s", err)
 	}
@@ -126,11 +126,16 @@ func TestVSphereLogin(t *testing.T) {
 	defer cancel()
 
 	// Create vSphere client
-	err = vs.conn.Connect(ctx)
+   var vcInstance* VSphereInstance
+   if vcInstance, ok = vs.vsphereInstanceMap[cfg.Global.VCenterIP]; !ok {
+      t.Fatalf("Couldn't get vSphere instance: %s", cfg.Global.VCenterIP)
+   }
+
+	err = vcInstance.conn.Connect(ctx)
 	if err != nil {
 		t.Errorf("Failed to connect to vSphere: %s", err)
 	}
-	defer vs.conn.GoVmomiClient.Logout(ctx)
+	defer vcInstance.conn.GoVmomiClient.Logout(ctx)
 }
 
 func TestZones(t *testing.T) {
@@ -154,7 +159,7 @@ func TestInstances(t *testing.T) {
 		t.Skipf("No config found in environment")
 	}
 
-	vs, err := newVSphere(cfg)
+	vs, err := newControllerNode(cfg)
 	if err != nil {
 		t.Fatalf("Failed to construct/authenticate vSphere: %s", err)
 	}
@@ -213,7 +218,7 @@ func TestVolumes(t *testing.T) {
 		t.Skipf("No config found in environment")
 	}
 
-	vs, err := newVSphere(cfg)
+	vs, err := newControllerNode(cfg)
 	if err != nil {
 		t.Fatalf("Failed to construct/authenticate vSphere: %s", err)
 	}

--- a/pkg/controller/node/node_controller.go
+++ b/pkg/controller/node/node_controller.go
@@ -591,20 +591,12 @@ func (nc *Controller) monitorNodeStatus() error {
 		} else {
 			nc.cancelPodEviction(added[i])
 		}
-		instance, isSupported := nc.cloud.Instances()
-		if isSupported {
-			instance.NodeRegistered(added[i])
-		}
 	}
 
 	for i := range deleted {
 		glog.V(1).Infof("Controller observed a Node deletion: %v", deleted[i].Name)
 		util.RecordNodeEvent(nc.recorder, deleted[i].Name, string(deleted[i].UID), v1.EventTypeNormal, "RemovingNode", fmt.Sprintf("Removing Node %v from Controller", deleted[i].Name))
 		delete(nc.knownNodeSet, deleted[i].Name)
-		instance, isSupported := nc.cloud.Instances()
-		if isSupported {
-			instance.NodeUnregistered(deleted[i])
-		}
 	}
 
 	zoneToNodeConditions := map[string][]*v1.NodeCondition{}


### PR DESCRIPTION
After discussion with community people, it was decided to to modify vsphere cloud provider to make use of passed ClientBuilder for listening to Node Events (added, deleted).

This change removes earlier added NodeRegistered, NodeUnregistered APIs in all cloud-providers and node_controller and uses ClientBuilder in vSphere::Initialize() method to get access to NodeInformer.
Using NodeInformer  VCP gets required node notifications.

Also fixed vsphere_test.go.
make test now passes for vsphere 

Testing done:
- Created hyperkube image and deployed it. Checked controller logs for Node added notifications.
- Removed (powered-off and deleted from inventory) k8s worker node and using kubectl removed node from the k8s cluster. Verified in the logs that Node deleted event is seen.

This will fix: https://github.com/vmware/kubernetes/issues/334

@abrarshivani, @SandeepPissay Please review the PR.
