### PR TITLE
Implemented CreateVolume for multi-vc support

### DIFF
--- a/pkg/cloudprovider/providers/vsphere/nodemanager.go
+++ b/pkg/cloudprovider/providers/vsphere/nodemanager.go
@@ -49,6 +49,11 @@ type NodeManager struct {
 	nodeInfoLock        sync.RWMutex
 }
 
+type NodeDetails struct {
+	NodeName string
+	vm       *vclib.VirtualMachine
+}
+
 // TODO: Make it configurable in vsphere.conf
 const (
 	POOL_SIZE  = 8
@@ -260,14 +265,14 @@ func (nm *NodeManager) GetNodeInfo(nodeName k8stypes.NodeName) (NodeInfo, error)
 	return *nodeInfo, nil
 }
 
-func (nm *NodeManager) GetNodeVms() []*vclib.VirtualMachine {
+func (nm *NodeManager) GetNodeDetails() []NodeDetails {
 	nm.nodeInfoLock.RLock()
 	defer nm.nodeInfoLock.RUnlock()
-	var nodeVms []*vclib.VirtualMachine
-	for _, nodeInfo := range nm.nodeInfoMap {
-		nodeVms = append(nodeVms, nodeInfo.vm)
+	var nodeDetails []NodeDetails
+	for nodeName, nodeInfo := range nm.nodeInfoMap {
+		nodeDetails = append(nodeDetails, NodeDetails{nodeName, nodeInfo.vm})
 	}
-	return nodeVms
+	return nodeDetails
 }
 
 func (nm *NodeManager) addNodeInfo(nodeName string, nodeInfo *NodeInfo) {

--- a/pkg/cloudprovider/providers/vsphere/nodemanager.go
+++ b/pkg/cloudprovider/providers/vsphere/nodemanager.go
@@ -260,6 +260,16 @@ func (nm *NodeManager) GetNodeInfo(nodeName k8stypes.NodeName) (NodeInfo, error)
 	return *nodeInfo, nil
 }
 
+func (nm *NodeManager) GetNodeVms() []*vclib.VirtualMachine {
+	nm.nodeInfoLock.RLock()
+	defer nm.nodeInfoLock.RUnlock()
+	var nodeVms []*vclib.VirtualMachine
+	for _, nodeInfo := range nm.nodeInfoMap {
+		nodeVms = append(nodeVms, nodeInfo.vm)
+	}
+	return nodeVms
+}
+
 func (nm *NodeManager) addNodeInfo(nodeName string, nodeInfo *NodeInfo) {
 	nm.nodeInfoLock.Lock()
 	nm.nodeInfoMap[nodeName] = nodeInfo

--- a/pkg/cloudprovider/providers/vsphere/vclib/constants.go
+++ b/pkg/cloudprovider/providers/vsphere/vclib/constants.go
@@ -43,7 +43,7 @@ const (
 	LogLevel                 = 4
 	DatastoreProperty        = "datastore"
 	ResourcePoolProperty     = "resourcePool"
-	DatastoreInfoProperty    = "info"
+	DatastoreNameProperty    = "name"
 	VirtualMachineType       = "VirtualMachine"
 	RoundTripperDefaultCount = 3
 	VSANDatastoreType        = "vsan"

--- a/pkg/cloudprovider/providers/vsphere/vclib/constants.go
+++ b/pkg/cloudprovider/providers/vsphere/vclib/constants.go
@@ -43,7 +43,7 @@ const (
 	LogLevel                 = 4
 	DatastoreProperty        = "datastore"
 	ResourcePoolProperty     = "resourcePool"
-	DatastoreNameProperty    = "name"
+	DatastoreInfoProperty    = "info"
 	VirtualMachineType       = "VirtualMachine"
 	RoundTripperDefaultCount = 3
 	VSANDatastoreType        = "vsan"

--- a/pkg/cloudprovider/providers/vsphere/vclib/datacenter.go
+++ b/pkg/cloudprovider/providers/vsphere/vclib/datacenter.go
@@ -94,6 +94,23 @@ func (dc *Datacenter) GetVMByPath(ctx context.Context, vmPath string) (*VirtualM
 	return &virtualMachine, nil
 }
 
+// TODO: Add doc
+func (dc *Datacenter) GetAllDatastores(ctx context.Context) ([]*Datastore, error) {
+	finder := getFinder(dc)
+	datastores, err := finder.DatastoreList(ctx, "*")
+	if err != nil {
+		glog.Errorf("Failed to get all the datastores. err: %+v", err)
+		return nil, err
+	}
+	var dsList []*Datastore
+	for _, datastore := range datastores {
+		dsList = append(dsList, &(Datastore{datastore, dc}))
+	}
+
+	return dsList, nil
+
+}
+
 // GetDatastoreByPath gets the Datastore object from the given vmDiskPath
 func (dc *Datacenter) GetDatastoreByPath(ctx context.Context, vmDiskPath string) (*Datastore, error) {
 	datastorePathObj := new(object.DatastorePath)
@@ -122,6 +139,23 @@ func (dc *Datacenter) GetDatastoreByName(ctx context.Context, name string) (*Dat
 	}
 	datastore := Datastore{ds, dc}
 	return &datastore, nil
+}
+
+// TODO: Add doc
+func (dc *Datacenter) GetResourcePool(ctx context.Context, computePath string) (*object.ResourcePool, error) {
+	finder := getFinder(dc)
+	var computeResource *object.ComputeResource
+	var err error
+	if computePath == "" {
+		computeResource, err = finder.DefaultComputeResource(ctx)
+	} else {
+		computeResource, err = finder.ComputeResource(ctx, computePath)
+	}
+	if err != nil {
+		glog.Errorf("Failed to get the ResourcePool for computePath '%s'. err: %+v", computePath, err)
+		return nil, err
+	}
+	return computeResource.ResourcePool(ctx)
 }
 
 // GetFolderByPath gets the Folder Object from the given folder path

--- a/pkg/cloudprovider/providers/vsphere/vclib/datacenter.go
+++ b/pkg/cloudprovider/providers/vsphere/vclib/datacenter.go
@@ -94,7 +94,8 @@ func (dc *Datacenter) GetVMByPath(ctx context.Context, vmPath string) (*VirtualM
 	return &virtualMachine, nil
 }
 
-// TODO: Add doc
+// GetAllDatastores gets the datastore URL to DatastoreInfo map for all the datastores in
+// the datacenter.
 func (dc *Datacenter) GetAllDatastores(ctx context.Context) (map[string]*DatastoreInfo, error) {
 	finder := getFinder(dc)
 	datastores, err := finder.DatastoreList(ctx, "*")
@@ -124,8 +125,7 @@ func (dc *Datacenter) GetAllDatastores(ctx context.Context) (map[string]*Datasto
 				dc},
 			dsMo.Info.GetDatastoreInfo()}
 	}
-	// TODO: Remove this log
-	glog.V(4).Infof("dsUrlInfoMap : %+v", dsUrlInfoMap)
+	glog.V(9).Infof("dsUrlInfoMap : %+v", dsUrlInfoMap)
 	return dsUrlInfoMap, nil
 }
 
@@ -159,7 +159,7 @@ func (dc *Datacenter) GetDatastoreByName(ctx context.Context, name string) (*Dat
 	return &datastore, nil
 }
 
-// TODO: Add doc
+// GetResourcePool gets the resource pool for the given path
 func (dc *Datacenter) GetResourcePool(ctx context.Context, computePath string) (*object.ResourcePool, error) {
 	finder := getFinder(dc)
 	var computeResource *object.ComputeResource

--- a/pkg/cloudprovider/providers/vsphere/vclib/datastore.go
+++ b/pkg/cloudprovider/providers/vsphere/vclib/datastore.go
@@ -24,12 +24,23 @@ import (
 	"github.com/vmware/govmomi/vim25/soap"
 	"github.com/vmware/govmomi/vim25/types"
 	"golang.org/x/net/context"
+	"fmt"
 )
 
 // Datastore extends the govmomi Datastore object
 type Datastore struct {
 	*object.Datastore
 	Datacenter *Datacenter
+}
+
+// Structure to store the Datastore and it's Info.
+type DatastoreInfo struct {
+	*Datastore
+	Info *types.DatastoreInfo
+}
+
+func (di DatastoreInfo) String() string {
+	return fmt.Sprintf("Datastore : %+v, URL : %s", di.Datastore, di.Info.Url)
 }
 
 // CreateDirectory creates the directory at location specified by directoryPath.

--- a/pkg/cloudprovider/providers/vsphere/vclib/datastore.go
+++ b/pkg/cloudprovider/providers/vsphere/vclib/datastore.go
@@ -40,7 +40,7 @@ type DatastoreInfo struct {
 }
 
 func (di DatastoreInfo) String() string {
-	return fmt.Sprintf("Datastore : %+v, URL : %s", di.Datastore, di.Info.Url)
+	return fmt.Sprintf("Datastore: %+v, datastore URL: %s", di.Datastore, di.Info.Url)
 }
 
 // CreateDirectory creates the directory at location specified by directoryPath.

--- a/pkg/cloudprovider/providers/vsphere/vclib/pbm.go
+++ b/pkg/cloudprovider/providers/vsphere/vclib/pbm.go
@@ -85,7 +85,7 @@ func (pbmClient *PbmClient) IsDatastoreCompatible(ctx context.Context, storagePo
 
 // GetCompatibleDatastores filters and returns compatible list of datastores for given storage policy id
 // For Non Compatible Datastores, fault message with the Datastore Name is also returned
-func (pbmClient *PbmClient) GetCompatibleDatastores(ctx context.Context, storagePolicyID string, datastores []*Datastore) ([]*Datastore, string, error) {
+func (pbmClient *PbmClient) GetCompatibleDatastores(ctx context.Context, dc *Datacenter, storagePolicyID string, datastores []*Datastore) ([]*Datastore, string, error) {
 	var (
 		dsMorNameMap                                = getDsMorNameMap(ctx, datastores)
 		localizedMessagesForNotCompatibleDatastores = ""

--- a/pkg/cloudprovider/providers/vsphere/vclib/pbm.go
+++ b/pkg/cloudprovider/providers/vsphere/vclib/pbm.go
@@ -85,7 +85,7 @@ func (pbmClient *PbmClient) IsDatastoreCompatible(ctx context.Context, storagePo
 
 // GetCompatibleDatastores filters and returns compatible list of datastores for given storage policy id
 // For Non Compatible Datastores, fault message with the Datastore Name is also returned
-func (pbmClient *PbmClient) GetCompatibleDatastores(ctx context.Context, dc *Datacenter, storagePolicyID string, datastores []*Datastore) ([]*Datastore, string, error) {
+func (pbmClient *PbmClient) GetCompatibleDatastores(ctx context.Context, dc *Datacenter, storagePolicyID string, datastores []*DatastoreInfo) ([]*DatastoreInfo, string, error) {
 	var (
 		dsMorNameMap                                = getDsMorNameMap(ctx, datastores)
 		localizedMessagesForNotCompatibleDatastores = ""
@@ -96,7 +96,7 @@ func (pbmClient *PbmClient) GetCompatibleDatastores(ctx context.Context, dc *Dat
 		return nil, "", err
 	}
 	compatibleHubs := compatibilityResult.CompatibleDatastores()
-	var compatibleDatastoreList []*Datastore
+	var compatibleDatastoreList []*DatastoreInfo
 	for _, hub := range compatibleHubs {
 		compatibleDatastoreList = append(compatibleDatastoreList, getDatastoreFromPlacementHub(datastores, hub))
 	}
@@ -121,7 +121,7 @@ func (pbmClient *PbmClient) GetCompatibleDatastores(ctx context.Context, dc *Dat
 }
 
 // GetPlacementCompatibilityResult gets placement compatibility result based on storage policy requirements.
-func (pbmClient *PbmClient) GetPlacementCompatibilityResult(ctx context.Context, storagePolicyID string, datastore []*Datastore) (pbm.PlacementCompatibilityResult, error) {
+func (pbmClient *PbmClient) GetPlacementCompatibilityResult(ctx context.Context, storagePolicyID string, datastore []*DatastoreInfo) (pbm.PlacementCompatibilityResult, error) {
 	var hubs []pbmtypes.PbmPlacementHub
 	for _, ds := range datastore {
 		hubs = append(hubs, pbmtypes.PbmPlacementHub{
@@ -145,7 +145,7 @@ func (pbmClient *PbmClient) GetPlacementCompatibilityResult(ctx context.Context,
 }
 
 // getDataStoreForPlacementHub returns matching datastore associated with given pbmPlacementHub
-func getDatastoreFromPlacementHub(datastore []*Datastore, pbmPlacementHub pbmtypes.PbmPlacementHub) *Datastore {
+func getDatastoreFromPlacementHub(datastore []*DatastoreInfo, pbmPlacementHub pbmtypes.PbmPlacementHub) *DatastoreInfo {
 	for _, ds := range datastore {
 		if ds.Reference().Type == pbmPlacementHub.HubType && ds.Reference().Value == pbmPlacementHub.HubId {
 			return ds
@@ -155,7 +155,7 @@ func getDatastoreFromPlacementHub(datastore []*Datastore, pbmPlacementHub pbmtyp
 }
 
 // getDsMorNameMap returns map of ds Mor and Datastore Object Name
-func getDsMorNameMap(ctx context.Context, datastores []*Datastore) map[string]string {
+func getDsMorNameMap(ctx context.Context, datastores []*DatastoreInfo) map[string]string {
 	dsMorNameMap := make(map[string]string)
 	for _, ds := range datastores {
 		dsObjectName, err := ds.ObjectName(ctx)

--- a/pkg/cloudprovider/providers/vsphere/vclib/virtualmachine.go
+++ b/pkg/cloudprovider/providers/vsphere/vclib/virtualmachine.go
@@ -244,8 +244,7 @@ func (vm *VirtualMachine) GetAllAccessibleDatastores(ctx context.Context) ([]*Da
 			" dsObjList: %+v, properties: %+v, err: %v", dsRefList, properties, err)
 		return nil, err
 	}
-	// TODO: Remove this log
-	glog.V(4).Infof("Result dsMoList: %+v", dsMoList)
+	glog.V(9).Infof("Result dsMoList: %+v", dsMoList)
 	var dsObjList []*DatastoreInfo
 	for _, dsMo := range dsMoList {
 		dsObjList = append(dsObjList,

--- a/pkg/cloudprovider/providers/vsphere/vsphere.go
+++ b/pkg/cloudprovider/providers/vsphere/vsphere.go
@@ -152,7 +152,7 @@ type VSphereConfig struct {
 		Datacenter       string `gcfg:"datacenter"`
 		Folder           string `gcfg:"folder"`
 		DefaultDatastore string `gcfg:"default-datastore"`
-		ComputePath      string `gcfg:"compute-path"`
+		ResourcePoolPath string `gcfg:"resourcepool-path"`
 	}
 }
 
@@ -224,7 +224,7 @@ func (vs *VSphere) Initialize(clientBuilder controller.ControllerClientBuilder) 
 		DeleteFunc: vs.NodeDeleted,
 	})
 	go nodeInformer.Informer().Run(wait.NeverStop)
-   glog.V(4).Infof("vSphere cloud provider initialized")
+	glog.V(4).Infof("vSphere cloud provider initialized")
 }
 
 // Creates new worker node interface and returns
@@ -926,7 +926,7 @@ func (vs *VSphere) CreateVolume(volumeOptions *vclib.VolumeOptions) (volumePath 
 				cleanUpRoutineInitialized = true
 			}
 			cleanUpRoutineInitLock.Unlock()
-			vmOptions, err = vs.setVMOptions(ctx, dc, vs.cfg.Workspace.ComputePath)
+			vmOptions, err = vs.setVMOptions(ctx, dc, vs.cfg.Workspace.ResourcePoolPath)
 			if err != nil {
 				glog.Errorf("Failed to set VM options requires to create a vsphere volume. err: %+v", err)
 				return "", err
@@ -1033,7 +1033,7 @@ func (vs *VSphere) HasClusterID() bool {
 func (vs *VSphere) NodeAdded(obj interface{}) {
 	node, ok := obj.(*v1.Node)
 	if node == nil || !ok {
-      glog.Warningf("NodeAdded: unrecognized object %+v", obj);
+		glog.Warningf("NodeAdded: unrecognized object %+v", obj)
 		return
 	}
 
@@ -1045,11 +1045,10 @@ func (vs *VSphere) NodeAdded(obj interface{}) {
 func (vs *VSphere) NodeDeleted(obj interface{}) {
 	node, ok := obj.(*v1.Node)
 	if node == nil || !ok {
-      glog.Warningf("NodeDeleted: unrecognized object %+v", obj);
+		glog.Warningf("NodeDeleted: unrecognized object %+v", obj)
 		return
 	}
 
 	glog.V(4).Infof("Node deleted: %+v", node)
 	vs.nodeManager.UnRegisterNode(node)
 }
-

--- a/pkg/cloudprovider/providers/vsphere/vsphere.go
+++ b/pkg/cloudprovider/providers/vsphere/vsphere.go
@@ -939,6 +939,8 @@ func (vs *VSphere) CreateVolume(volumeOptions *vclib.VolumeOptions) (volumePath 
 				return "", err
 			}
 		} else {
+			// Since no storage policy is specified but datastore is specified, check
+			// if the given datastore is a shared datastore across all node VMs.
 			sharedDsList, err := getSharedDatastoresInK8SCluster(ctx, dc, vs.nodeManager)
 			if err != nil {
 				glog.Errorf("Failed to get shared datastore: %+v", err)

--- a/pkg/cloudprovider/providers/vsphere/vsphere_util.go
+++ b/pkg/cloudprovider/providers/vsphere/vsphere_util.go
@@ -35,6 +35,8 @@ import (
 
 	"k8s.io/kubernetes/pkg/cloudprovider/providers/vsphere/vclib"
 	"k8s.io/kubernetes/pkg/cloudprovider/providers/vsphere/vclib/diskmanagers"
+	"github.com/vmware/govmomi/vim25/soap"
+	"github.com/vmware/govmomi/vim25/types"
 )
 
 const (
@@ -141,55 +143,83 @@ func getvmUUID() (string, error) {
 	return uuid, nil
 }
 
+func getAccessibleDatastores(ctx context.Context, nodeVmDetail *NodeDetails, nodeManager *NodeManager) ([]*vclib.DatastoreInfo, error) {
+	accessibleDatastores, err := nodeVmDetail.vm.GetAllAccessibleDatastores(ctx)
+	if err != nil {
+		if IsManagedObjectNotFoundError(err) {
+			glog.V(4).Infof("error %q ManagedObjectNotFound for node %q. Rediscovering...", err, nodeVmDetail.NodeName)
+			err = nodeManager.RediscoverNode(convertToK8sType(nodeVmDetail.NodeName))
+			if err == nil {
+				glog.V(4).Infof("Discovered node %s successfully", nodeVmDetail.NodeName)
+				nodeInfo, err := nodeManager.GetNodeInfo(convertToK8sType(nodeVmDetail.NodeName))
+				if err != nil {
+					glog.V(4).Infof("error %q getting node info for node %+v", err, nodeVmDetail)
+					return nil, err
+				}
+
+				accessibleDatastores, err = nodeInfo.vm.GetAllAccessibleDatastores(ctx)
+				if err != nil {
+					glog.V(4).Infof("error %q getting accessible datastores for node %+v", err, nodeVmDetail)
+					return nil, err
+				}
+			} else {
+				glog.V(4).Infof("error %q rediscovering node %+v", err, nodeVmDetail)
+				return nil, err
+			}
+		} else {
+			glog.V(4).Infof("error %q getting accessible datastores for node %+v", err, nodeVmDetail)
+			return nil, err
+		}
+	}
+	return accessibleDatastores, nil
+}
+
 // Get all datastores accessible for the virtual machine object.
-func getSharedDatastoresInK8SCluster(ctx context.Context, nodeManager *NodeManager) ([]string, error) {
-	vmList := nodeManager.GetNodeVms()
-	if vmList == nil || len(vmList) == 0 {
-		msg := fmt.Sprintf("Kubernetes node vm list is empty. vmList : %+v", vmList)
+func getSharedDatastoresInK8SCluster(ctx context.Context, dc *vclib.Datacenter, nodeManager *NodeManager) ([]*vclib.DatastoreInfo, error) {
+	nodeVmDetails := nodeManager.GetNodeDetails()
+	if nodeVmDetails == nil || len(nodeVmDetails) == 0 {
+		msg := fmt.Sprintf("Kubernetes node nodeVmDetail details is empty. nodeVmDetails : %+v", nodeVmDetails)
 		glog.Error(msg)
 		return nil, fmt.Errorf(msg)
 	}
 	index := 0
-	var sharedDatastores []string
-	for _, vm := range vmList {
-		vmName, err := vm.ObjectName(ctx)
+	var sharedDatastores []*vclib.DatastoreInfo
+	for _, nodeVmDetail := range nodeVmDetails {
+		glog.V(4).Infof("Getting accessible datastores for node %s", nodeVmDetail.NodeName)
+		accessibleDatastores, err := getAccessibleDatastores(ctx, &nodeVmDetail, nodeManager)
 		if err != nil {
 			return nil, err
 		}
-		if !strings.HasPrefix(vmName, DummyVMPrefixName) {
-			accessibleDatastores, err := vm.GetAllAccessibleDatastores(ctx)
-			if err != nil {
-				return nil, err
+		if index == 0 {
+			sharedDatastores = accessibleDatastores
+		} else {
+			sharedDatastores = intersect(sharedDatastores, accessibleDatastores)
+			if len(sharedDatastores) == 0 {
+				return nil, fmt.Errorf("No shared datastores found in the Kubernetes cluster for nodeVmDetails: %+v", nodeVmDetails)
 			}
-			if index == 0 {
-				sharedDatastores = accessibleDatastores
-			} else {
-				// Note that we are using datastore names for intersection. For multi-vc support, we are assuming that the
-				// datastore names are same for the shared storage across datacenters and virtual centers. This is because,
-				// the PVs will have the datastore name in the volume path if old version of k8s is used or due to upgrade
-				// or due to static provisioning or PVs. Using datastore URLs in PVs, VCP logic, vsphere.config,
-				// storage class etc should be thought through more.
-				// TODO: THIS IS WRONG! Use datastoreURL for intersection!!!
-				// Ideally we should intersect on datastore URLs here.
-				sharedDatastores = intersect(sharedDatastores, accessibleDatastores)
-				if len(sharedDatastores) == 0 {
-					return nil, fmt.Errorf("No shared datastores found in the Kubernetes cluster for vmList: %+v", vmList)
-				}
-			}
-			index++
 		}
+		index++
 	}
+	glog.V(4).Infof("sharedDatastores : %+v", sharedDatastores)
+	sharedDatastores, err := getDatastoresForEndpointVC(ctx, dc, sharedDatastores)
+	if err != nil {
+		glog.Errorf("Failed to get shared datastores from endpoint VC. err: %+v", err)
+		return nil, err
+	}
+	glog.V(4).Infof("sharedDatastores at endpoint VC: %+v", sharedDatastores)
 	return sharedDatastores, nil
 }
 
-func intersect(list1 []string, list2 []string) []string {
+func intersect(list1 []*vclib.DatastoreInfo, list2 []*vclib.DatastoreInfo) []*vclib.DatastoreInfo {
+	// TODO: Remove these logs
 	glog.V(4).Infof("list1: %+v", list1)
 	glog.V(4).Infof("list2: %+v", list2)
-	var sharedDs []string
+	var sharedDs []*vclib.DatastoreInfo
 	for _, val1 := range list1 {
 		// Check if val1 is found in list2
 		for _, val2 := range list2 {
-			if val1 == val2 {
+			// Intersect is performed based on the datastoreUrl as this uniquely identifies the datastore.
+			if val1.Info.Url == val2.Info.Url {
 				sharedDs = append(sharedDs, val1)
 				break
 			}
@@ -218,35 +248,36 @@ func getAllAccessibleDatastores(ctx context.Context, client *vim25.Client, vmMo 
 }
 
 // getMostFreeDatastore gets the best fit compatible datastore by free space.
-func getMostFreeDatastoreName(ctx context.Context, client *vim25.Client, dsObjList []*vclib.Datastore) (string, error) {
-	dsMoList, err := dsObjList[0].Datacenter.GetDatastoreMoList(ctx, dsObjList, []string{DatastoreInfoProperty})
-	if err != nil {
-		return "", err
-	}
+func getMostFreeDatastoreName(ctx context.Context, client *vim25.Client, dsInfoList []*vclib.DatastoreInfo) (string, error) {
 	var curMax int64
 	curMax = -1
 	var index int
-	for i, dsMo := range dsMoList {
-		dsFreeSpace := dsMo.Info.GetDatastoreInfo().FreeSpace
+	for i, dsInfo := range dsInfoList {
+		dsFreeSpace := dsInfo.Info.GetDatastoreInfo().FreeSpace
 		if dsFreeSpace > curMax {
 			curMax = dsFreeSpace
 			index = i
 		}
 	}
-	return dsMoList[index].Info.GetDatastoreInfo().Name, nil
+	return dsInfoList[index].Info.GetDatastoreInfo().Name, nil
 }
 
-func getDatastoresForEndpointVC(ctx context.Context, dc *vclib.Datacenter, dsNames []string) []*vclib.Datastore {
-	var datastores []*vclib.Datastore
-	for _, dsName := range dsNames {
-		ds, err := dc.GetDatastoreByName(ctx, dsName)
-		if err != nil {
-			glog.V(4).Infof("Warning: Could not find datastore with name %s in datacenter %s! Ignoring it..", dsName, dc.Name())
-			continue
-		}
-		datastores = append(datastores, ds)
+func getDatastoresForEndpointVC(ctx context.Context, dc *vclib.Datacenter, sharedDsInfos []*vclib.DatastoreInfo) ([]*vclib.DatastoreInfo, error) {
+	var datastores []*vclib.DatastoreInfo
+	allDsInfoMap, err := dc.GetAllDatastores(ctx)
+	if err != nil {
+		return nil, err
 	}
-	return datastores
+	for _, sharedDsInfo := range sharedDsInfos {
+		dsInfo, ok := allDsInfoMap[sharedDsInfo.Info.Url]
+		if ok {
+			datastores = append(datastores, dsInfo)
+		} else {
+			glog.V(4).Infof("Warning: Shared datastore with URL %s does not exist in endpoint VC", sharedDsInfo.Info.Url)
+		}
+	}
+	glog.V(4).Infof("Datastore from endpoint VC: %+v", datastores)
+	return datastores, nil
 }
 
 func getPbmCompatibleDatastore(ctx context.Context, dc *vclib.Datacenter, storagePolicyName string, nodeManager *NodeManager) (string, error) {
@@ -259,27 +290,31 @@ func getPbmCompatibleDatastore(ctx context.Context, dc *vclib.Datacenter, storag
 		glog.Errorf("Failed to get Profile ID by name: %s. err: %+v", storagePolicyName, err)
 		return "", err
 	}
-	sharedDs, err := getSharedDatastoresInK8SCluster(ctx, nodeManager)
+	sharedDs, err := getSharedDatastoresInK8SCluster(ctx, dc, nodeManager)
 	if err != nil {
 		glog.Errorf("Failed to get shared datastores. err: %+v", err)
 		return "", err
 	}
-	sharedDsList := getDatastoresForEndpointVC(ctx, dc, sharedDs)
-	if len(sharedDsList) == 0 {
+	if len(sharedDs) == 0 {
 		msg := "No shared datastores found in the endpoint virtual center"
 		glog.Errorf(msg)
 		return "", errors.New(msg)
 	}
-	compatibleDatastores, _, err := pbmClient.GetCompatibleDatastores(ctx, dc, storagePolicyID, sharedDsList)
+	compatibleDatastores, _, err := pbmClient.GetCompatibleDatastores(ctx, dc, storagePolicyID, sharedDs)
 	if err != nil {
-		glog.Errorf("Failed to get compatible datastores from datastores : %+v with storagePolicy: %s. err: %+v", sharedDsList, storagePolicyID, err)
+		glog.Errorf("Failed to get compatible datastores from datastores : %+v with storagePolicy: %s. err: %+v",
+			sharedDs, storagePolicyID, err)
 		return "", err
 	}
+	// TODO: remove this log
+	glog.V(4).Infof("compatibleDatastores : %+v", compatibleDatastores)
 	datastore, err := getMostFreeDatastoreName(ctx, dc.Client(), compatibleDatastores)
 	if err != nil {
 		glog.Errorf("Failed to get most free datastore from compatible datastores: %+v. err: %+v", compatibleDatastores, err)
 		return "", err
 	}
+	// TODO: remove this log
+	glog.V(4).Infof("Most free datastore : %+s", datastore)
 	return datastore, err
 }
 
@@ -289,6 +324,7 @@ func (vs *VSphere) setVMOptions(ctx context.Context, dc *vclib.Datacenter, compu
 	if err != nil {
 		return nil, err
 	}
+	glog.V(4).Infof("Compute path %s, resourcePool %+v", computePath, resourcePool)
 	folder, err := dc.GetFolderByPath(ctx, vs.cfg.Workspace.Folder)
 	if err != nil {
 		return nil, err
@@ -328,4 +364,12 @@ func (vs *VSphere) cleanUpDummyVMs(dummyVMPrefix string) {
 			glog.V(4).Infof("Unable to clean up dummy VM's in the kubernetes cluster: %q. err: %+v", vs.cfg.Global.WorkingDir, err)
 		}
 	}
+}
+
+func IsManagedObjectNotFoundError(err error) bool {
+	isManagedObjectNotFoundError := false
+	if soap.IsSoapFault(err) {
+		_, isManagedObjectNotFoundError = soap.ToSoapFault(err).VimFault().(types.ManagedObjectNotFound)
+	}
+	return isManagedObjectNotFoundError
 }

--- a/pkg/cloudprovider/providers/vsphere/vsphere_util.go
+++ b/pkg/cloudprovider/providers/vsphere/vsphere_util.go
@@ -354,14 +354,14 @@ func (vs *VSphere) cleanUpDummyVMs(dummyVMPrefix string) {
 		// Get the folder reference for global working directory where the dummy VM needs to be created.
 		vmFolder, err := dc.GetFolderByPath(ctx, vs.cfg.Workspace.Folder)
 		if err != nil {
-			glog.V(4).Infof("Unable to get the kubernetes folder: %q reference. err: %+v", vs.cfg.Global.WorkingDir, err)
+			glog.V(4).Infof("Unable to get the kubernetes folder: %q reference. err: %+v", vs.cfg.Workspace.Folder, err)
 			continue
 		}
 		// A write lock is acquired to make sure the cleanUp routine doesn't delete any VM's created by ongoing PVC requests.
 		defer cleanUpDummyVMLock.Lock()
 		err = diskmanagers.CleanUpDummyVMs(ctx, vmFolder, dc)
 		if err != nil {
-			glog.V(4).Infof("Unable to clean up dummy VM's in the kubernetes cluster: %q. err: %+v", vs.cfg.Global.WorkingDir, err)
+			glog.V(4).Infof("Unable to clean up dummy VM's in the kubernetes cluster: %q. err: %+v", vs.cfg.Workspace.Folder, err)
 		}
 	}
 }

--- a/pkg/cloudprovider/providers/vsphere/vsphere_util.go
+++ b/pkg/cloudprovider/providers/vsphere/vsphere_util.go
@@ -296,13 +296,13 @@ func getPbmCompatibleDatastore(ctx context.Context, dc *vclib.Datacenter, storag
 	return datastore, err
 }
 
-func (vs *VSphere) setVMOptions(ctx context.Context, dc *vclib.Datacenter, computePath string) (*vclib.VMOptions, error) {
+func (vs *VSphere) setVMOptions(ctx context.Context, dc *vclib.Datacenter, resourcePoolPath string) (*vclib.VMOptions, error) {
 	var vmOptions vclib.VMOptions
-	resourcePool, err := dc.GetResourcePool(ctx, computePath)
+	resourcePool, err := dc.GetResourcePool(ctx, resourcePoolPath)
 	if err != nil {
 		return nil, err
 	}
-	glog.V(9).Infof("Compute path %s, resourcePool %+v", computePath, resourcePool)
+	glog.V(9).Infof("Resource pool path %s, resourcePool %+v", resourcePoolPath, resourcePool)
 	folder, err := dc.GetFolderByPath(ctx, vs.cfg.Workspace.Folder)
 	if err != nil {
 		return nil, err

--- a/pkg/cloudprovider/providers/vsphere/vsphere_util.go
+++ b/pkg/cloudprovider/providers/vsphere/vsphere_util.go
@@ -181,9 +181,8 @@ func getSharedDatastoresInK8SCluster(ctx context.Context, dc *vclib.Datacenter, 
 		glog.Error(msg)
 		return nil, fmt.Errorf(msg)
 	}
-	index := 0
 	var sharedDatastores []*vclib.DatastoreInfo
-	for _, nodeVmDetail := range nodeVmDetails {
+	for index, nodeVmDetail := range nodeVmDetails {
 		glog.V(9).Infof("Getting accessible datastores for node %s", nodeVmDetail.NodeName)
 		accessibleDatastores, err := getAccessibleDatastores(ctx, &nodeVmDetail, nodeManager)
 		if err != nil {
@@ -197,7 +196,6 @@ func getSharedDatastoresInK8SCluster(ctx context.Context, dc *vclib.Datacenter, 
 				return nil, fmt.Errorf("No shared datastores found in the Kubernetes cluster for nodeVmDetails: %+v", nodeVmDetails)
 			}
 		}
-		index++
 	}
 	glog.V(9).Infof("sharedDatastores : %+v", sharedDatastores)
 	sharedDatastores, err := getDatastoresForEndpointVC(ctx, dc, sharedDatastores)


### PR DESCRIPTION
Implemented CreateVolume for multi-vc support

Summary:
1. Modified the CreateVolume workflow so that we find out the shared datastores across the node VMs that are spread across multiple vCenter Servers. The shared datastore is computed by comparing the datastore URLs of the datastores accessible for the node VMs. 
2. Added logic to rediscover the node VM if the VM's data in node manager is stale while computing the shared datastores across node VMs.
3. Modified the logic that talks to SPBM to get compatible datastores to use correct shared datastores,
4. Fixed the code to handle error out volume creation when storage policy is not specified but a non-shared datastore is specified for the volume.
5. Introduced compute path under Workspace. This is the resource pool used to create dummy VMs.

Testing done:
1. With storage policy and no datastore specified: All node VMs are in one VC. create/delete succeeded. Moved 1 worker to another VC. Create rediscovered the node since it was stale in node manager, computed the shared datastore properly and volume creation succeeded.
2. With no policy and with local datastore specified in storage class: All node VMs in one VC. create/delete succeeded since the local datastore was a common datastore. Moved 1 worker to another VC. Create rediscovered the node and compute the shared datastores properly. Since this is local only to VC1, the create volume failed as expected.
3. With no policy and with shared datastore in storage class: All nodes in one VC. create/delete succeeded. Moved 1 worker to another VC. Create rediscovered the node and computed the shared datastore correctly. Since the user has specified shared datastore across VCs, the create volume succeeded.