### PR TITLE
Using CRD instead of TPRs in Enable-VCP UX script

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ To enable the vSphere Cloud Provider on Kubernetes Cluster, users need to follow
 
 Some of the steps, for example, creating roles and privileges assignment, enabling advanced properties on the Kubernetes nodes etc. requires vSphere administration skill. To help developers quickly get started with enabling vSphere Cloud Provider we have automated most of the vCenter administration steps. To know detail about automation architecture and design please visit this [link](https://github.com/vmware/kubernetes/issues/224).
 
-Automation takes care of the following tasks: 
+Automation takes care of the following tasks:
 
  * Create working directory VM folders for Kubernetes node VMs if not present.
  * Move node VMs to the working directory VM folder.
@@ -16,19 +16,19 @@ Automation takes care of the following tasks:
  * Reload kubelet service unit and restart Kubelet service on all nodes to apply the configuration.
 
 ## How to kick off auto configuration
-Automation script files are located at [https://github.com/vmware/kubernetes/tree/enable-vcp-uxi](https://github.com/vmware/kubernetes/tree/enable-vcp-uxi). 
+Automation script files are located at [https://github.com/vmware/kubernetes/tree/enable-vcp-uxi](https://github.com/vmware/kubernetes/tree/enable-vcp-uxi).
 
 Scripts are bundled in the docker image located at https://hub.docker.com/r/cnastorage/enablevcp
 
 Following are the Prerequisites for this automation.
- 
+
  * We need a vCenter admin username and password.
  * Separate user for vSphere Cloud Provider needs to be pre-created on the vCenter. This Step is optional but recommended.
  * Daemonset Pods should be allowed to be scheduled on all nodes. If Kubernetes is deployed using kubeadm, we see the taint ```node-role.kubernetes.io/master``` on the master node. Make sure to remove this taint. Taint can be removed using the following command.
 
     ```kubectl taint nodes --all node-role.kubernetes.io/master-```
- 
- 
+
+
 Let's get started with how to use these automation scripts.
 
 **The first step** is to download following YAML files :
@@ -165,7 +165,7 @@ Deploy them in the following sequence.
 **Note:** Make sure kubectl is configured to use `kubernetes-admin` user. When Kubebernetes cluster is deployed using kubeadm, we see couple of config files (`admin.conf`, `kubelet.conf`) at /etc/kubernetes on the master node. Make sure to configure kubectl to use `admin.conf` We need `kubernetes-admin` user to create `serviceaccount` and `clusterrolebinding`.
 
 ```bash
-$ kubectl create -f vcp_namespace_account_and_roles.yaml 
+$ kubectl create -f vcp_namespace_account_and_roles.yaml
 namespace "vmware" created
 serviceaccount "vcpsa" created
 clusterrolebinding "sa-vmware-default-binding" created
@@ -174,7 +174,7 @@ clusterrolebinding "sa-vmware-vcpsa-binding" created
 $ kubectl create --save-config -f vcp_secret.yaml
 secret "vsphere-cloud-provider-secret" created
 
-$ kubectl create -f enable-vsphere-cloud-provider.yaml 
+$ kubectl create -f enable-vsphere-cloud-provider.yaml
 pod "vcp-manager" created
 ```
 
@@ -266,17 +266,18 @@ if you want to perform the cleanup, execute following commands in sequence.
 
 ```bash
 kubectl delete pod vcp-manager --namespace vmware
-
 kubectl delete daemonset vcp-daementset --namespace vmware
 
-kubectl delete ThirdPartyResources vcp-status.vmware.com
+(Kubernetes 1.8 and above)
+kubectl delete customresourcedefinitions vcpstatuses.vmware.com
+kubectl delete customresourcedefinitions vcpsummaries.vmware.com
 
+(Kubernetes 1.7)
+kubectl delete ThirdPartyResources vcp-status.vmware.com
 kubectl delete ThirdPartyResources vcp-summary.vmware.com
 
 kubectl delete secret vsphere-cloud-provider-secret --namespace=vmware
-
 kubectl delete serviceaccount vcpsa --namespace=vmware
-
 kubectl delete clusterrolebinding sa-vmware-default-binding  sa-vmware-vcpsa-binding
 
 kubectl delete namespace vmware
@@ -303,15 +304,22 @@ Delete existing configuration resources.
 ```bash
 kubectl delete pod vcp-manager --namespace vmware
 kubectl delete daemonset vcp-daementset --namespace vmware
+
+(Kubernetes 1.8 and above)
+kubectl delete customresourcedefinitions vcpstatuses.vmware.com
+kubectl delete customresourcedefinitions vcpsummaries.vmware.com
+
+(Kubernetes 1.7)
 kubectl delete ThirdPartyResources vcp-status.vmware.com
 kubectl delete ThirdPartyResources vcp-summary.vmware.com
+
 kubectl delete secret vsphere-cloud-provider-secret --namespace=vmware
 ```
 Re-create Secret and vcp-manager and daemon set pod.
 
 ```
 kubectl create --save-config -f vcp_secret.yaml
-kubectl create -f enable-vsphere-cloud-provider.yaml 
+kubectl create -f enable-vsphere-cloud-provider.yaml
 ```
 
 Roll back progress can be monitored from the logs on the Daemon Pods. Once roll back is finished, you can clean up the configuration resources as mentioned above.

--- a/enable-vcp-image/enable-vcp-scripts/vcp-daemontset.yaml
+++ b/enable-vcp-image/enable-vcp-scripts/vcp-daemontset.yaml
@@ -1,20 +1,3 @@
----
-apiVersion: extensions/v1beta1
-kind: ThirdPartyResource
-metadata:
-  name: vcp-status.vmware.com
-description: "POD status resource"
-versions:
-- name: v1
----
-apiVersion: extensions/v1beta1
-kind: ThirdPartyResource
-metadata:
-  name: vcp-summary.vmware.com
-description: "Overall Summary of vSphere Cloud Provider configuration operations"
-versions:
-- name: v1
----
 apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:

--- a/enable-vcp-image/enable-vcp-scripts/vcp-summary-crd.yaml
+++ b/enable-vcp-image/enable-vcp-scripts/vcp-summary-crd.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: vcpstatuses.vmware.com
+spec:
+  group: vmware.com
+  version: v1
+  names:
+    kind: VcpStatus
+    plural: vcpstatuses
+  scope: Cluster
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: vcpsummaries.vmware.com
+spec:
+  group: vmware.com
+  version: v1
+  names:
+    kind: VcpSummary
+    plural: vcpsummaries
+  scope: Cluster

--- a/enable-vcp-image/enable-vcp-scripts/vcp-summary-tpr.yaml
+++ b/enable-vcp-image/enable-vcp-scripts/vcp-summary-tpr.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: extensions/v1beta1
+kind: ThirdPartyResource
+metadata:
+  name: vcp-status.vmware.com
+description: "POD status resource"
+versions:
+- name: v1
+---
+apiVersion: extensions/v1beta1
+kind: ThirdPartyResource
+metadata:
+  name: vcp-summary.vmware.com
+description: "Overall Summary of vSphere Cloud Provider configuration operations"
+versions:
+- name: v1
+---


### PR DESCRIPTION
Fixes https://github.com/vmware/kubernetes/issues/429

Testing:
Built a new docker image from the changes.
Using it in enable-vsphere-cloud-provider.yaml as 
```
    - name: vcp-manager-container
      image: pshahzeb/vcp-ux:latest
```
```
root@promc-2n-dhcp105-23:~# kubectl taint nodes --all node-role.kubernetes.io/master-
node "promc-2n-dhcp105-23" untainted
root@promc-2n-dhcp105-23:~# kubectl taint nodes --all node-role.kubernetes.io/master-
error: taint "node-role.kubernetes.io/master:" not found
root@promc-2n-dhcp105-23:~# sysctl net.bridge.bridge-nf-call-iptables=1
net.bridge.bridge-nf-call-iptables = 1
root@promc-2n-dhcp105-23:~# kubectl apply -f https://raw.githubusercontent.com/coreos/flannel/v0.9.1/Documentation/kube-flannel.yml
clusterrole "flannel" created
clusterrolebinding "flannel" created
serviceaccount "flannel" created
configmap "kube-flannel-cfg" created
daemonset "kube-flannel-ds" created
root@promc-2n-dhcp105-23:~# kubectl get pods --namespace=vmware
No resources found.
root@promc-2n-dhcp105-23:~# kubectl get pods --all-namespaces
NAMESPACE     NAME                                          READY     STATUS    RESTARTS   AGE
kube-system   etcd-promc-2n-dhcp105-23                      1/1       Running   0          26s
kube-system   kube-apiserver-promc-2n-dhcp105-23            1/1       Running   0          22s
kube-system   kube-controller-manager-promc-2n-dhcp105-23   1/1       Running   0          19s
kube-system   kube-dns-6f4fd4bdf-8c67s                      0/3       Pending   0          57s
kube-system   kube-flannel-ds-wfqvb                         1/1       Running   0          18s
kube-system   kube-proxy-d9qxr                              1/1       Running   0          57s
kube-system   kube-scheduler-promc-2n-dhcp105-23            1/1       Running   0          15s
root@promc-2n-dhcp105-23:~# kubectl get pods --all-namespaces
NAMESPACE     NAME                                          READY     STATUS    RESTARTS   AGE
kube-system   etcd-promc-2n-dhcp105-23                      1/1       Running   0          1m
kube-system   kube-apiserver-promc-2n-dhcp105-23            1/1       Running   0          1m
kube-system   kube-controller-manager-promc-2n-dhcp105-23   1/1       Running   0          1m
kube-system   kube-dns-6f4fd4bdf-8c67s                      3/3       Running   0          1m
kube-system   kube-flannel-ds-wfqvb                         1/1       Running   0          1m
kube-system   kube-proxy-d9qxr                              1/1       Running   0          1m
kube-system   kube-scheduler-promc-2n-dhcp105-23            1/1       Running   0          1m
root@promc-2n-dhcp105-23:~# kubectl get nodes
NAME                  STATUS     ROLES     AGE       VERSION
promc-2n-dhcp105-23   Ready      master    2m        v1.9.1
worker1               NotReady   <none>    7s        v1.9.1
root@promc-2n-dhcp105-23:~# kubectl get nodes
NAME                  STATUS     ROLES     AGE       VERSION
promc-2n-dhcp105-23   Ready      master    2m        v1.9.1
worker1               NotReady   <none>    10s       v1.9.1
root@promc-2n-dhcp105-23:~# kubectl get nodes
NAME                  STATUS    ROLES     AGE       VERSION
promc-2n-dhcp105-23   Ready     master    3m        v1.9.1
worker1               Ready     <none>    1m        v1.9.1
root@promc-2n-dhcp105-23:~# kubectl create -f vcp_namespace_account_and_roles.yaml
namespace "vmware" created
serviceaccount "vcpsa" created
clusterrolebinding "sa-vmware-default-binding" created
clusterrolebinding "sa-vmware-vcpsa-binding" created
root@promc-2n-dhcp105-23:~# kubectl create --save-config -f vcp_secret.yaml
secret "vsphere-cloud-provider-secret" created
root@promc-2n-dhcp105-23:~# kubectl create -f enable-vsphere-cloud-provider.yaml
pod "vcp-manager" created
root@promc-2n-dhcp105-23:~# kubectl get VcpSummary --namespace=vmware -o json
{
    "apiVersion": "v1",
    "items": [
        {
            "apiVersion": "vmware.com/v1",
            "kind": "VcpSummary",
            "metadata": {
                "annotations": {
                    "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"vmware.com/v1\",\"kind\":\"VcpSummary\",\"metadata\":{\"annotations\":{},\"name\":\"vcpinstallstatus\",\"namespace\":\"\"},\"spec\":{\"nodes_being_configured\":\"0\",\"nodes_failed_to_configure\":\"0\",\"nodes_in_phase1\":\"0\",\"nodes_in_phase2\":\"0\",\"nodes_in_phase3\":\"0\",\"nodes_in_phase4\":\"0\",\"nodes_in_phase5\":\"0\",\"nodes_in_phase6\":\"0\",\"nodes_in_phase7\":\"0\",\"nodes_sucessfully_configured\":\"2\",\"total_number_of_nodes\":\"2\"}}\n"
                },
                "clusterName": "",
                "creationTimestamp": "2018-01-13T20:25:55Z",
                "generation": 0,
                "name": "vcpinstallstatus",
                "namespace": "",
                "resourceVersion": "839",
                "selfLink": "/apis/vmware.com/v1/vcpinstallstatus",
                "uid": "f56120dc-f89f-11e7-8567-005056a16704"
            },
            "spec": {
                "nodes_being_configured": "0",
                "nodes_failed_to_configure": "0",
                "nodes_in_phase1": "0",
                "nodes_in_phase2": "0",
                "nodes_in_phase3": "0",
                "nodes_in_phase4": "0",
                "nodes_in_phase5": "0",
                "nodes_in_phase6": "0",
                "nodes_in_phase7": "0",
                "nodes_sucessfully_configured": "2",
                "total_number_of_nodes": "2"
            }
        }
    ],
    "kind": "List",
    "metadata": {
        "resourceVersion": "",
        "selfLink": ""
    }
}

```