### PR TITLE
Node delete (unregister) test to verify node discovery work flow

### DIFF
--- a/test/e2e/storage/vsphere/BUILD
+++ b/test/e2e/storage/vsphere/BUILD
@@ -21,6 +21,7 @@ go_library(
         "vsphere_volume_disksize.go",
         "vsphere_volume_fstype.go",
         "vsphere_volume_master_restart.go",
+        "vsphere_volume_node_delete.go",
         "vsphere_volume_node_poweroff.go",
         "vsphere_volume_ops_storm.go",
         "vsphere_volume_perf.go",

--- a/test/e2e/storage/vsphere/vsphere_volume_node_delete.go
+++ b/test/e2e/storage/vsphere/vsphere_volume_node_delete.go
@@ -1,0 +1,148 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vsphere
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/vmware/govmomi/find"
+	"golang.org/x/net/context"
+
+	vimtypes "github.com/vmware/govmomi/vim25/types"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/pkg/cloudprovider/providers/vsphere"
+	"k8s.io/kubernetes/test/e2e/framework"
+	"k8s.io/kubernetes/test/e2e/storage/utils"
+	"time"
+	"github.com/vmware/govmomi/vim25/mo"
+)
+
+var _ = utils.SIGDescribe("Node Delete [Feature:vsphere] [Slow] [Disruptive]", func() {
+	f := framework.NewDefaultFramework("node-unregister")
+	var (
+		client     clientset.Interface
+		namespace  string
+		vsp        *vsphere.VSphere
+		workingDir string
+		err        error
+	)
+
+	BeforeEach(func() {
+		framework.SkipUnlessProviderIs("vsphere")
+		client = f.ClientSet
+		namespace = f.Namespace.Name
+		framework.ExpectNoError(framework.WaitForAllNodesSchedulable(client, framework.TestContext.NodeSchedulableTimeout))
+		vsp, err = getVSphere(client)
+		Expect(err).NotTo(HaveOccurred())
+		workingDir = os.Getenv("VSPHERE_WORKING_DIR")
+		Expect(workingDir).NotTo(BeEmpty())
+
+	})
+
+	It("node unregister", func() {
+
+		By("Get total Ready nodes")
+		nodeList := framework.GetReadySchedulableNodesOrDie(f.ClientSet)
+		Expect(nodeList.Items).NotTo(BeEmpty(), "Unable to find ready and schedulable Node")
+		Expect(len(nodeList.Items) > 1).To(BeTrue(), "At least 2 nodes are required for this test")
+
+		totalNodes := len(nodeList.Items)
+
+		node1 := nodeList.Items[0]
+
+		govMoMiClient, err := vsphere.GetgovmomiClient(nil)
+		Expect(err).NotTo(HaveOccurred())
+
+		finder := find.NewFinder(govMoMiClient.Client, true)
+		ctx, _ := context.WithCancel(context.Background())
+
+		vmPath := filepath.Join(workingDir, string(node1.ObjectMeta.Name))
+		vm, err := finder.VirtualMachine(ctx, vmPath)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Find .vmx file path to be used to re register the node
+		var nodeVM mo.VirtualMachine
+		err = vm.Properties(ctx, vm.Reference(), []string{"config.files"}, &nodeVM)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(nodeVM.Config).NotTo(BeNil())
+
+		vmFolder, err := finder.FolderOrDefault(ctx, workingDir)
+		Expect(err).NotTo(HaveOccurred())
+		host, err  := vm.HostSystem(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		rpool ,err := vm.ResourcePool(ctx)
+		Expect(err).NotTo(HaveOccurred())
+
+		By(fmt.Sprintf("Power off the node: %v", node1.ObjectMeta.Name))
+		_, err = vm.PowerOff(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		err = vm.WaitForPowerState(ctx, vimtypes.VirtualMachinePowerStatePoweredOff)
+		Expect(err).NotTo(HaveOccurred(), "Unable to power off the node")
+
+		By(fmt.Sprintf("Unregister the node: %v", node1.ObjectMeta.Name))
+		err = vm.Unregister(ctx)
+		Expect(err).NotTo(HaveOccurred(), "Unable to unregister the node")
+
+		// Ready nodes should be 1 less
+		verifyReadyNodes(f.ClientSet, totalNodes - 1)
+
+		By(fmt.Sprintf("Register the node: %v", node1.ObjectMeta.Name))
+		registerTask, err := vmFolder.RegisterVM(ctx, nodeVM.Config.Files.VmPathName, node1.ObjectMeta.Name, false, rpool, host)
+		Expect(err).NotTo(HaveOccurred())
+		err = registerTask.Wait(ctx)
+		Expect(err).NotTo(HaveOccurred())
+
+		vm, err = finder.VirtualMachine(ctx, vmPath)
+		Expect(err).NotTo(HaveOccurred())
+
+		By(fmt.Sprintf("Power on the node: %v", node1.ObjectMeta.Name))
+		vm.PowerOn(ctx)
+		err = vm.WaitForPowerState(ctx, vimtypes.VirtualMachinePowerStatePoweredOn)
+		Expect(err).NotTo(HaveOccurred(), "Unable to power on the node")
+
+		// Ready nodes should be equal to earlier count
+		verifyReadyNodes(f.ClientSet, totalNodes)
+
+
+		// Sanity test that pod provisioning works
+		scParameters := make(map[string]string)
+		storagePolicy := os.Getenv("VSPHERE_SPBM_GOLD_POLICY")
+		Expect(storagePolicy).NotTo(BeEmpty(), "Please set VSPHERE_SPBM_GOLD_POLICY system environment")
+		scParameters[SpbmStoragePolicy] = storagePolicy
+		invokeValidPolicyTest(f, client, namespace, scParameters)
+	})
+})
+
+// verify ready status of nodes upto 1 minute
+func verifyReadyNodes(client clientset.Interface, expectedNodes int){
+	numNodes := 0
+	for i := 0; i < 31; i++ {
+		nodeList := framework.GetReadySchedulableNodesOrDie(client)
+		Expect(nodeList.Items).NotTo(BeEmpty(), "Unable to find ready and schedulable Node")
+		numNodes = len(nodeList.Items)
+		if numNodes == expectedNodes {
+			break
+		}
+		time.Sleep(5*time.Second)
+	}
+
+	Expect(numNodes).To(Equal(expectedNodes))
+}


### PR DESCRIPTION
Fixes https://github.com/vmware/kubernetes/issues/379

Test results
```
pshahzeb-m01:kubernetes_3 pshahzeb$ go run hack/e2e.go --check-version-skew=false --v --test --test_args='--ginkgo.focus=Node\sDelete'
flag provided but not defined: -check-version-skew
Usage of /var/folders/97/lnlv1n317xl2ty8hdn7zptxr00b37m/T/go-build124876510/command-line-arguments/_obj/exe/e2e:
  -get
    	go get -u kubetest if old or not installed (default true)
  -old duration
    	Consider kubetest old if it exceeds this (default 24h0m0s)
2018/01/10 15:42:35 e2e.go:55: NOTICE: go run hack/e2e.go is now a shim for test-infra/kubetest
2018/01/10 15:42:35 e2e.go:56:   Usage: go run hack/e2e.go [--get=true] [--old=24h0m0s] -- [KUBETEST_ARGS]
2018/01/10 15:42:35 e2e.go:57:   The separator is required to use --get or --old flags
2018/01/10 15:42:35 e2e.go:58:   The -- flag separator also suppresses this message
2018/01/10 15:42:35 e2e.go:77: Calling kubetest --check-version-skew=false --v --test --test_args=--ginkgo.focus=Node\sDelete...
2018/01/10 15:42:35 util.go:155: Running: ./cluster/kubectl.sh --match-server-version=false version
2018/01/10 15:42:35 util.go:157: Step './cluster/kubectl.sh --match-server-version=false version' finished in 130.692607ms
2018/01/10 15:42:35 util.go:155: Running: ./hack/e2e-internal/e2e-status.sh
Skeleton Provider: prepare-e2e not implemented
Client Version: version.Info{Major:"1", Minor:"6+", GitVersion:"v1.6.0-alpha.0.21153+f9e4b6d025fb88-dirty", GitCommit:"f9e4b6d025fb882da975377774dc330afefdd788", GitTreeState:"dirty", BuildDate:"2018-01-05T18:34:44Z", GoVersion:"go1.9.2", Compiler:"gc", Platform:"darwin/amd64"}
Server Version: version.Info{Major:"1", Minor:"9", GitVersion:"v1.9.0", GitCommit:"925c127ec6b946659ad0fd596fa959be43f0cc05", GitTreeState:"clean", BuildDate:"2017-12-15T20:55:30Z", GoVersion:"go1.9.2", Compiler:"gc", Platform:"linux/amd64"}
2018/01/10 15:42:35 util.go:157: Step './hack/e2e-internal/e2e-status.sh' finished in 143.13952ms
2018/01/10 15:42:35 util.go:155: Running: ./hack/ginkgo-e2e.sh --ginkgo.focus=Node\sDelete
Conformance test: not doing test setup.
Jan 10 15:42:35.955: INFO: Overriding default scale value of zero to 1
Jan 10 15:42:35.955: INFO: Overriding default milliseconds value of zero to 5000
I0110 15:42:36.032116   55624 e2e.go:331] Starting e2e run "ef868827-f65f-11e7-be77-784f435ee632" on Ginkgo node 1
Running Suite: Kubernetes e2e suite
===================================
Random Seed: 1515627755 - Will randomize all specs
Will run 1 of 715 specs

Jan 10 15:42:36.047: INFO: >>> kubeConfig: /tmp/kubeconfig.json
Jan 10 15:42:36.051: INFO: Waiting up to 4h0m0s for all (but 0) nodes to be schedulable
Jan 10 15:42:36.078: INFO: Waiting up to 10m0s for all pods (need at least 0) in namespace 'kube-system' to be running and ready
Jan 10 15:42:36.141: INFO: 11 / 11 pods in namespace 'kube-system' are running and ready (0 seconds elapsed)
Jan 10 15:42:36.141: INFO: expected 4 pod replicas in namespace 'kube-system', 4 are Running and Ready.
Jan 10 15:42:36.147: INFO: Waiting for pods to enter Success, but no pods in "kube-system" match label map[name:e2e-image-puller]
Jan 10 15:42:36.147: INFO: Dumping network health container logs from all nodes...
Jan 10 15:42:36.152: INFO: e2e test version: v1.6.0-alpha.0.21153+f9e4b6d025fb88-dirty
Jan 10 15:42:36.156: INFO: kube-apiserver version: v1.9.0
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
------------------------------
[sig-storage] Node Delete [Feature:vsphere] [Slow] [Disruptive]
  node unregister
  /Users/pshahzeb/k8s/kubernetes_3/_output/local/go/src/k8s.io/kubernetes/test/e2e/storage/vsphere/vsphere_volume_node_delete.go:60
[BeforeEach] [sig-storage] Node Delete [Feature:vsphere] [Slow] [Disruptive]
  /Users/pshahzeb/k8s/kubernetes_3/_output/local/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
STEP: Creating a kubernetes client
Jan 10 15:42:36.158: INFO: >>> kubeConfig: /tmp/kubeconfig.json
STEP: Building a namespace api object
Jan 10 15:42:36.244: INFO: No PodSecurityPolicies found; assuming PodSecurityPolicy is disabled.
STEP: Waiting for a default service account to be provisioned in namespace
[BeforeEach] [sig-storage] Node Delete [Feature:vsphere] [Slow] [Disruptive]
  /Users/pshahzeb/k8s/kubernetes_3/_output/local/go/src/k8s.io/kubernetes/test/e2e/storage/vsphere/vsphere_volume_node_delete.go:48
Jan 10 15:42:36.248: INFO: Waiting up to 4h0m0s for all (but 0) nodes to be schedulable
[It] node unregister
  /Users/pshahzeb/k8s/kubernetes_3/_output/local/go/src/k8s.io/kubernetes/test/e2e/storage/vsphere/vsphere_volume_node_delete.go:60
STEP: Get total Ready nodes
STEP: Power off the node: kubernetes-node1
STEP: Unregister the node: kubernetes-node1
STEP: Register the node: kubernetes-node1
STEP: Power on the node: kubernetes-node1
Jan 10 15:43:43.912: INFO: Condition Ready of node kubernetes-node1 is false instead of true. Reason: KubeletNotReady, message: container runtime is down
Jan 10 15:43:48.924: INFO: Condition Ready of node kubernetes-node1 is false instead of true. Reason: KubeletNotReady, message: container runtime is down
STEP: Creating Storage Class With storage policy params
STEP: Creating PVC using the Storage Class
STEP: Waiting for claim to be in bound phase
Jan 10 15:43:53.965: INFO: Waiting up to 5m0s for PersistentVolumeClaim pvc-65bb9 to have phase Bound
Jan 10 15:43:53.970: INFO: PersistentVolumeClaim pvc-65bb9 found but phase is Pending instead of Bound.
Jan 10 15:43:55.975: INFO: PersistentVolumeClaim pvc-65bb9 found but phase is Pending instead of Bound.
Jan 10 15:43:57.982: INFO: PersistentVolumeClaim pvc-65bb9 found but phase is Pending instead of Bound.
Jan 10 15:43:59.991: INFO: PersistentVolumeClaim pvc-65bb9 found but phase is Pending instead of Bound.
Jan 10 15:44:02.019: INFO: PersistentVolumeClaim pvc-65bb9 found but phase is Pending instead of Bound.
Jan 10 15:44:04.029: INFO: PersistentVolumeClaim pvc-65bb9 found but phase is Pending instead of Bound.
Jan 10 15:44:06.039: INFO: PersistentVolumeClaim pvc-65bb9 found and phase=Bound (12.073706851s)
STEP: Creating pod to attach PV to the node
STEP: Verify the volume is accessible and available in the pod
Jan 10 15:44:20.252: INFO: Running '/Users/pshahzeb/k8s/kubernetes_3/_output/bin/kubectl --server=https://10.161.112.0 --kubeconfig=/tmp/kubeconfig.json exec pvc-tester-ncvv6 --namespace=e2e-tests-node-unregister-rfmpt -- /bin/touch /mnt/volume1/emptyFile.txt'
Jan 10 15:44:20.490: INFO: stderr: ""
Jan 10 15:44:20.490: INFO: stdout: ""
STEP: Deleting pod
Jan 10 15:44:20.490: INFO: Deleting pod "pvc-tester-ncvv6" in namespace "e2e-tests-node-unregister-rfmpt"
Jan 10 15:44:20.500: INFO: Wait up to 5m0s for pod "pvc-tester-ncvv6" to be fully deleted
STEP: Waiting for volumes to be detached from the node
Jan 10 15:45:02.533: INFO: Volume "[vsanDatastore] 3aa5565a-d590-f948-6d63-020041fe8e56/kubernetes-dynamic-pvc-1e0ec0a0-f660-11e7-b040-0050569899ca.vmdk" has successfully detached from "kubernetes-node1"
Jan 10 15:45:02.533: INFO: Deleting PersistentVolumeClaim "pvc-65bb9"
[AfterEach] [sig-storage] Node Delete [Feature:vsphere] [Slow] [Disruptive]
  /Users/pshahzeb/k8s/kubernetes_3/_output/local/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
Jan 10 15:45:02.553: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
STEP: Destroying namespace "e2e-tests-node-unregister-rfmpt" for this suite.
Jan 10 15:45:08.575: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
Jan 10 15:45:08.720: INFO: namespace: e2e-tests-node-unregister-rfmpt, resource: bindings, ignored listing per whitelist
Jan 10 15:45:08.806: INFO: namespace e2e-tests-node-unregister-rfmpt deletion completed in 6.24785546s

• [SLOW TEST:152.646 seconds]
[sig-storage] Node Delete [Feature:vsphere] [Slow] [Disruptive]
/Users/pshahzeb/k8s/kubernetes_3/_output/local/go/src/k8s.io/kubernetes/test/e2e/storage/utils/framework.go:22
  node unregister
  /Users/pshahzeb/k8s/kubernetes_3/_output/local/go/src/k8s.io/kubernetes/test/e2e/storage/vsphere/vsphere_volume_node_delete.go:60
------------------------------
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSJan 10 15:45:08.807: INFO: Running AfterSuite actions on all node
Jan 10 15:45:08.807: INFO: Running AfterSuite actions on node 1

Ran 1 of 715 Specs in 152.757 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 714 Skipped PASS

Ginkgo ran 1 suite in 2m32.993708039s
Test Suite Passed
2018/01/10 15:45:08 util.go:157: Step './hack/ginkgo-e2e.sh --ginkgo.focus=Node\sDelete' finished in 2m33.374693924s
2018/01/10 15:45:08 e2e.go:81: Done
```