### PR TITLE
Remove vmUUID check in VCP

### DIFF
--- a/pkg/cloudprovider/providers/vsphere/vsphere.go
+++ b/pkg/cloudprovider/providers/vsphere/vsphere.go
@@ -375,14 +375,6 @@ func newControllerNode(cfg VSphereConfig) (*VSphere, error) {
 	if cfg.Global.VCenterPort == "" {
 		cfg.Global.VCenterPort = "443"
 	}
-	if cfg.Global.VMUUID == "" {
-		// This needs root privileges on the host, and will fail otherwise.
-		cfg.Global.VMUUID, err = getvmUUID()
-		if err != nil {
-			glog.Errorf("Failed to get VM UUID. err: %+v", err)
-			return nil, err
-		}
-	}
 	vsphereInstanceMap, err := populateVsphereInstanceMap(&cfg)
 	if err != nil {
 		return nil, err

--- a/pkg/cloudprovider/providers/vsphere/vsphere_util.go
+++ b/pkg/cloudprovider/providers/vsphere/vsphere_util.go
@@ -128,30 +128,6 @@ func GetgovmomiClient(conn *vclib.VSphereConnection) (*govmomi.Client, error) {
 	return client, err
 }
 
-// getvmUUID gets the BIOS UUID via the sys interface.  This UUID is known by vsphere
-func getvmUUID() (string, error) {
-	id, err := ioutil.ReadFile(UUIDPath)
-	if err != nil {
-		return "", fmt.Errorf("error retrieving vm uuid: %s", err)
-	}
-	uuidFromFile := string(id[:])
-	//strip leading and trailing white space and new line char
-	uuid := strings.TrimSpace(uuidFromFile)
-	// check the uuid starts with "VMware-"
-	if !strings.HasPrefix(uuid, UUIDPrefix) {
-		return "", fmt.Errorf("Failed to match Prefix, UUID read from the file is %v", uuidFromFile)
-	}
-	// Strip the prefix and while spaces and -
-	uuid = strings.Replace(uuid[len(UUIDPrefix):(len(uuid))], " ", "", -1)
-	uuid = strings.Replace(uuid, "-", "", -1)
-	if len(uuid) != 32 {
-		return "", fmt.Errorf("Length check failed, UUID read from the file is %v", uuidFromFile)
-	}
-	// need to add dashes, e.g. "564d395e-d807-e18a-cb25-b79f65eb2b9f"
-	uuid = fmt.Sprintf("%s-%s-%s-%s-%s", uuid[0:8], uuid[8:12], uuid[12:16], uuid[16:20], uuid[20:32])
-	return uuid, nil
-}
-
 // Returns the accessible datastores for the given node VM.
 func getAccessibleDatastores(ctx context.Context, nodeVmDetail *NodeDetails, nodeManager *NodeManager) ([]*vclib.DatastoreInfo, error) {
 	accessibleDatastores, err := nodeVmDetail.vm.GetAllAccessibleDatastores(ctx)


### PR DESCRIPTION
This PR addresses issue mentioned in https://github.com/vmware/kubernetes/issues/419.

The fix is to remove the check for vvmUUID in entirety from 1.9 branch - https://github.com/kubernetes/kubernetes/blob/master/pkg/cloudprovider/providers/vsphere/vsphere.go#L378 as it is not longer needed. The NodeInfo object by default provides this information.

This fix will this enable:
- Enable e2e test cases to be executed locally on Mac machines
- Remove unnecessary vmUUID code in 1.9 branch.

cc @prashima @divyenpatel 

Testing Done:
1. Deployed a kubernetes 1.9 cluster and verified the basic VCP operations works fine as expected. 

- Create SPBM policy defined storage class.
- Create PVC out of the storage class. Verified if disk got created successfully.
- Create Pod from PVC. Verified if attachment is successful.
- Delete Pod and verified detach is successful.
- Delete PVC and verify if disk got deleted successfully.
- Delete storageclass.