### PR TITLE
Adding a new e2e test to verify volume provisioning throws error if non-shared DS is used

### DIFF
--- a/test/e2e/storage/vsphere/vsphere_common.go
+++ b/test/e2e/storage/vsphere/vsphere_common.go
@@ -17,15 +17,17 @@ limitations under the License.
 package vsphere
 
 import (
-	. "github.com/onsi/gomega"
 	"os"
 	"strconv"
+
+	"k8s.io/kubernetes/test/e2e/framework"
 )
 
 const (
 	SPBMPolicyName            = "VSPHERE_SPBM_POLICY_NAME"
 	StorageClassDatastoreName = "VSPHERE_DATASTORE"
 	SecondSharedDatastore     = "VSPHERE_SECOND_SHARED_DATASTORE"
+	LocalDatastore            = "VSPHERE_LOCAL_DATASTORE"
 	KubernetesClusterName     = "VSPHERE_KUBERNETES_CLUSTER"
 	SPBMTagPolicy             = "VSPHERE_SPBM_TAG_POLICY"
 )
@@ -54,13 +56,17 @@ const (
 
 func GetAndExpectStringEnvVar(varName string) string {
 	varValue := os.Getenv(varName)
-	Expect(varValue).NotTo(BeEmpty(), "ENV "+varName+" is not set")
+	if varValue == "" {
+		framework.Skipf("Environment variable " + varName + " is not set. Skipping the test.")
+	}
 	return varValue
 }
 
 func GetAndExpectIntEnvVar(varName string) int {
 	varValue := GetAndExpectStringEnvVar(varName)
 	varIntValue, err := strconv.Atoi(varValue)
-	Expect(err).NotTo(HaveOccurred(), "Error Parsing "+varName)
+	if err != nil {
+		framework.Skipf("Error parsing " + varName + ", which is expected to be an integer value. Skipping the test.")
+	}
 	return varIntValue
 }

--- a/test/e2e/storage/vsphere/vsphere_volume_datastore.go
+++ b/test/e2e/storage/vsphere/vsphere_volume_datastore.go
@@ -18,7 +18,6 @@ package vsphere
 
 import (
 	"fmt"
-	"os"
 	"strings"
 	"time"
 
@@ -81,12 +80,7 @@ var _ = utils.SIGDescribe("Volume Provisioning on Datastore [Feature:vsphere]", 
 
 	It("should fail provisioning pv on local datastore", func() {
 		By("Invoking Test for local datastore")
-		localDatastore = os.Getenv("LOCAL_DATASTORE")
-		if localDatastore == "" {
-			framework.Skipf("Environment variable LOCAL_DATASTORE is not set. Skipping the test.")
-		} else {
-			framework.Logf("Running test against configured local datastore: %s", localDatastore)
-		}
+		localDatastore = GetAndExpectStringEnvVar(LocalDatastore)
 		scParameters[Datastore] = localDatastore
 		scParameters[DiskFormat] = ThinDisk
 		err := invokeDatastoreTestNeg(client, namespace, scParameters)

--- a/test/e2e/storage/vsphere/vsphere_volume_datastore.go
+++ b/test/e2e/storage/vsphere/vsphere_volume_datastore.go
@@ -67,7 +67,7 @@ var _ = utils.SIGDescribe("Volume Provisioning on Datastore [Feature:vsphere]", 
 		}
 	})
 
-	It("verify dynamically provisioned pv using storageclass fails on an invalid datastore", func() {
+	It("should fail provisioning pv on invalid datastore", func() {
 		By("Invoking Test for invalid datastore")
 		scParameters[Datastore] = InvalidDatastore
 		scParameters[DiskFormat] = ThinDisk
@@ -79,11 +79,13 @@ var _ = utils.SIGDescribe("Volume Provisioning on Datastore [Feature:vsphere]", 
 		}
 	})
 
-	It("verify dynamically provisioned pv using storageclass fails on a local datastore", func() {
+	It("should fail provisioning pv on local datastore", func() {
 		By("Invoking Test for local datastore")
 		localDatastore = os.Getenv("LOCAL_DATASTORE")
 		if localDatastore == "" {
 			framework.Skipf("Environment variable LOCAL_DATASTORE is not set. Skipping the test.")
+		} else {
+			framework.logf("Running test against configured local datastore: %s", localDatastore)
 		}
 		scParameters[Datastore] = localDatastore
 		scParameters[DiskFormat] = ThinDisk

--- a/test/e2e/storage/vsphere/vsphere_volume_datastore.go
+++ b/test/e2e/storage/vsphere/vsphere_volume_datastore.go
@@ -85,7 +85,7 @@ var _ = utils.SIGDescribe("Volume Provisioning on Datastore [Feature:vsphere]", 
 		if localDatastore == "" {
 			framework.Skipf("Environment variable LOCAL_DATASTORE is not set. Skipping the test.")
 		} else {
-			framework.logf("Running test against configured local datastore: %s", localDatastore)
+			framework.Logf("Running test against configured local datastore: %s", localDatastore)
 		}
 		scParameters[Datastore] = localDatastore
 		scParameters[DiskFormat] = ThinDisk


### PR DESCRIPTION
**What this PR does / why we need it**:
Adding a new e2e test to verify volume provisioning throws error if non-shared DS is used

**Which issue(s) this PR fixes**:
Fixes #372 

**Testing Done**:

**1. When environment variable LOCAL_DATASTORE is not set**

$ go run hack/e2e.go --check-version-skew=false -v --test --test_args='--ginkgo.focus=Volume\sProvisioning\son\sDatastore'
......
[sig-storage] Volume Provisioning on Datastore [Feature:vsphere] 
  should fail provisioning pv on local datastore
  
[It] should fail provisioning pv on local datastore
STEP: Invoking Test for local datastore
Jan 19 14:47:41.322: INFO: Environment variable VSPHERE_LOCAL_DATASTORE is not set. Skipping the test.
S [SKIPPING] [6.832 seconds]
......
Ran 1 of 717 Specs in 135.753 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 716 Skipped PASS

**2. When environment variable LOCAL_DATASTORE is set**

$ go run hack/e2e.go --check-version-skew=false -v --test --test_args='--ginkgo.focus=Volume\sProvisioning\son\sDatastore'
......
[It] should fail provisioning pv on local datastore
  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/storage/vsphere/vsphere_volume_datastore.go:81
STEP: Invoking Test for local datastore
STEP: Creating Storage Class with given datastore
STEP: Creating PVC using the Storage Class
STEP: Expect claim to fail provisioning volume
......
Ran 2 of 717 Specs in 255.194 seconds
SUCCESS! -- 2 Passed | 0 Failed | 0 Pending | 715 Skipped PASS