### PR TITLE
Created bootstrapping logic for vSphere tests

### DIFF
--- a/test/e2e/storage/vsphere/BUILD
+++ b/test/e2e/storage/vsphere/BUILD
@@ -27,6 +27,8 @@ go_library(
         "vsphere_volume_perf.go",
         "vsphere_volume_placement.go",
         "vsphere_volume_vsan_policy.go",
+        "bootstrap/context.go",
+        "bootstrap/bootstrap.go",
     ],
     importpath = "k8s.io/kubernetes/test/e2e/storage/vsphere",
     deps = [

--- a/test/e2e/storage/vsphere/bootstrap/bootstrap.go
+++ b/test/e2e/storage/vsphere/bootstrap/bootstrap.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package bootstrap
 
 import (
@@ -11,10 +27,10 @@ func Bootstrap() {
 	done := make(chan bool)
 	go func() {
 		once.Do(bootstrapOnce)
-		<- waiting
+		<-waiting
 		done <- true
 	}()
-	<- done
+	<-done
 }
 
 func bootstrapOnce() {

--- a/test/e2e/storage/vsphere/bootstrap/bootstrap.go
+++ b/test/e2e/storage/vsphere/bootstrap/bootstrap.go
@@ -1,0 +1,27 @@
+package bootstrap
+
+import (
+	"sync"
+)
+
+var once sync.Once
+var waiting = make(chan bool)
+
+func Bootstrap() {
+	done := make(chan bool)
+	go func() {
+		once.Do(bootstrapOnce)
+		<- waiting
+		done <- true
+	}()
+	<- done
+}
+
+func bootstrapOnce() {
+	// TBD
+	// 1. Read vSphere conf and get VSphere instances
+	// 2. Get Node to VSphere mapping
+	// 3. Set NodeMapper in vSphere context
+	TestContext = Context{}
+	close(waiting)
+}

--- a/test/e2e/storage/vsphere/bootstrap/bootstrap.go
+++ b/test/e2e/storage/vsphere/bootstrap/bootstrap.go
@@ -23,6 +23,7 @@ import (
 var once sync.Once
 var waiting = make(chan bool)
 
+// Bootstrap takes care of initializing necessary test context for vSphere tests
 func Bootstrap() {
 	done := make(chan bool)
 	go func() {

--- a/test/e2e/storage/vsphere/bootstrap/context.go
+++ b/test/e2e/storage/vsphere/bootstrap/context.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package bootstrap
 
 type Context struct {

--- a/test/e2e/storage/vsphere/bootstrap/context.go
+++ b/test/e2e/storage/vsphere/bootstrap/context.go
@@ -1,0 +1,7 @@
+package bootstrap
+
+type Context struct {
+	// NodeMapper and other instances, common to vSphere tests
+}
+
+var TestContext Context

--- a/test/e2e/storage/vsphere/bootstrap/context.go
+++ b/test/e2e/storage/vsphere/bootstrap/context.go
@@ -16,6 +16,7 @@ limitations under the License.
 
 package bootstrap
 
+// Context holds common information for vSphere tests
 type Context struct {
 	// NodeMapper and other instances, common to vSphere tests
 }

--- a/test/e2e/storage/vsphere/vsphere_volume_fstype.go
+++ b/test/e2e/storage/vsphere/vsphere_volume_fstype.go
@@ -29,7 +29,6 @@ import (
 	vsphere "k8s.io/kubernetes/pkg/cloudprovider/providers/vsphere"
 	"k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/e2e/storage/utils"
-	"k8s.io/kubernetes/test/e2e/storage/vsphere/bootstrap"
 )
 
 const (

--- a/test/e2e/storage/vsphere/vsphere_volume_fstype.go
+++ b/test/e2e/storage/vsphere/vsphere_volume_fstype.go
@@ -29,6 +29,7 @@ import (
 	vsphere "k8s.io/kubernetes/pkg/cloudprovider/providers/vsphere"
 	"k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/e2e/storage/utils"
+	"k8s.io/kubernetes/test/e2e/storage/vsphere/bootstrap"
 )
 
 const (


### PR DESCRIPTION
**What this PR does / why we need it**:
Add bootstrapping logic and Context for vSphere tests. This context can be utilized to hold information like node-vsphere mapping, which needs to be initialized only once per test suit run.

sync.Once takes care of executing bootstrapping only once for all the specs. 'waiting' channel takes care of making sure that parallel test spec executions wait for bootstrapping to finish before moving on.

**Which issue(s) this PR fixes** 
Fixes #437, partly

**Special notes for your reviewer**:
Successfully ran make.
Tested by added additional log messages to bootstrap process (now removed). Made sure bootstrapping logic is getting invoked just once and bootstrapping is done by the time It-blocks are executed.

**Release note**:
```release-note
NONE
```
