### PR TITLE
Fixing node labels assignment and checkDiskAttached func

### DIFF
--- a/pkg/cloudprovider/providers/vsphere/vsphere.go
+++ b/pkg/cloudprovider/providers/vsphere/vsphere.go
@@ -1112,7 +1112,7 @@ func (vs *VSphere) DisksAreAttached(volPaths []string, nodeName k8stypes.NodeNam
 func checkDiskAttached(volPath string, vmdevices object.VirtualDeviceList, dc *object.Datacenter, client *govmomi.Client) (bool, error) {
 	_, err := getVirtualDiskControllerKey(volPath, vmdevices, dc, client)
 	if err != nil {
-		if err == ErrNoDevicesFound {
+		if err == ErrNoDevicesFound || err == ErrNoDiskUUIDFound {
 			return false, nil
 		}
 		glog.Errorf("Failed to check whether disk is attached. err: %s", err)

--- a/test/e2e/storage/vsphere_volume_diskformat.go
+++ b/test/e2e/storage/vsphere_volume_diskformat.go
@@ -28,8 +28,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8stype "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/uuid"
-	"k8s.io/kubernetes/pkg/client/clientset_generated/clientset"
 	"k8s.io/kubernetes/pkg/api/v1"
+	"k8s.io/kubernetes/pkg/client/clientset_generated/clientset"
 	vsphere "k8s.io/kubernetes/pkg/cloudprovider/providers/vsphere"
 	"k8s.io/kubernetes/test/e2e/framework"
 )
@@ -75,14 +75,14 @@ var _ = framework.KubeDescribe("Volume Disk Format [Feature:vsphere]", func() {
 		if !isNodeLabeled {
 			nodeLabelValue := "vsphere_e2e_" + string(uuid.NewUUID())
 			nodeKeyValueLabel = make(map[string]string)
-			nodeKeyValueLabel["vsphere_e2e_label"] = nodeLabelValue
-			framework.AddOrUpdateLabelOnNode(client, nodeName, "vsphere_e2e_label", nodeLabelValue)
+			nodeKeyValueLabel["vsphere_e2e_label_volume_diskformat"] = nodeLabelValue
+			framework.AddOrUpdateLabelOnNode(client, nodeName, "vsphere_e2e_label_volume_diskformat", nodeLabelValue)
 			isNodeLabeled = true
 		}
 	})
 	framework.AddCleanupAction(func() {
 		if len(nodeLabelValue) > 0 {
-			framework.RemoveLabelOffNode(client, nodeName, "vsphere_e2e_label")
+			framework.RemoveLabelOffNode(client, nodeName, "vsphere_e2e_label_volume_diskformat")
 		}
 	})
 

--- a/test/e2e/storage/vsphere_volume_placement.go
+++ b/test/e2e/storage/vsphere_volume_placement.go
@@ -77,10 +77,10 @@ var _ = framework.KubeDescribe("Volume Placement", func() {
 	*/
 	framework.AddCleanupAction(func() {
 		if len(node1KeyValueLabel) > 0 {
-			framework.RemoveLabelOffNode(c, node1Name, "vsphere_e2e_label")
+			framework.RemoveLabelOffNode(c, node1Name, "vsphere_e2e_label_volume_placement")
 		}
 		if len(node2KeyValueLabel) > 0 {
-			framework.RemoveLabelOffNode(c, node2Name, "vsphere_e2e_label")
+			framework.RemoveLabelOffNode(c, node2Name, "vsphere_e2e_label_volume_placement")
 		}
 	})
 	/*
@@ -335,13 +335,13 @@ func testSetupVolumePlacement(client clientset.Interface, namespace string) (nod
 	node2Name = nodes.Items[1].Name
 	node1LabelValue := "vsphere_e2e_" + string(uuid.NewUUID())
 	node1KeyValueLabel = make(map[string]string)
-	node1KeyValueLabel["vsphere_e2e_label"] = node1LabelValue
-	framework.AddOrUpdateLabelOnNode(client, node1Name, "vsphere_e2e_label", node1LabelValue)
+	node1KeyValueLabel["vsphere_e2e_label_volume_placement"] = node1LabelValue
+	framework.AddOrUpdateLabelOnNode(client, node1Name, "vsphere_e2e_label_volume_placement", node1LabelValue)
 
 	node2LabelValue := "vsphere_e2e_" + string(uuid.NewUUID())
 	node2KeyValueLabel = make(map[string]string)
-	node2KeyValueLabel["vsphere_e2e_label"] = node2LabelValue
-	framework.AddOrUpdateLabelOnNode(client, node2Name, "vsphere_e2e_label", node2LabelValue)
+	node2KeyValueLabel["vsphere_e2e_label_volume_placement"] = node2LabelValue
+	framework.AddOrUpdateLabelOnNode(client, node2Name, "vsphere_e2e_label_volume_placement", node2LabelValue)
 	return node1Name, node1KeyValueLabel, node2Name, node2KeyValueLabel
 }
 


### PR DESCRIPTION
Fixes: https://github.com/vmware/kubernetes/issues/424

**For some e2e test cases we are setting node labels to control pod scheduling on specific node.**

When tests are executed in random order from testsuite, they are overwriting node labels, so some tests were failing to schedule pod on desired node. Tests were failing with following error.

“FailedScheduling: No nodes are available that match all of the predicates: MatchNodeSelector (5), NodeUnschedulable (1).

This PR is fixing the above issue with using unique node label key for group of test cases within test suite.



**For some e2e test cases, I observed tests were failing with `No disk UUID found` error.** 

While checking for disk attachment with node VM there is chance that `QueryVirtualDiskUuid()`  may return this error due to disk is already detached/deleted. Issue is fixed with handing this error in `vsphere.go -> checkDiskAttached` function.



Test_Failed: Kubernetes e2e suite.[k8s.io] PersistentVolumes [Feature:ReclaimPolicy] [k8s.io] persistentvolumereclaim:vsphere should not detach and unmount PV when associated pvc with delete as reclaimPolicy is deleted when it is in use by the pod_

Error Log
```
/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/storage/pv_reclaimpolicy.go:148
Expected error:
    <*errors.errorString | 0xc42011e7b0>: {
        s: "No disk UUID found",
    }
    No disk UUID found
not to have occurred
/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/storage/vsphere_utils.go:52
```

**Executed couple of Nightly Jobs with this fix. All tests passed**

http://cna-storage-jenkins.eng.vmware.com/job/k8s-release-1.7-validation/32/ (All Test Passed)
http://cna-storage-jenkins.eng.vmware.com/job/k8s-release-1.7-validation/31/ (All Test Passed)

```
Ran 40 of 660 Specs in 5219.003 seconds
SUCCESS! -- 40 Passed | 0 Failed | 0 Pending | 620 Skipped PASS
```
