### PR TITLE
Use SetInformers method to register for Node events.

### DIFF
--- a/pkg/cloudprovider/providers/vsphere/vsphere.go
+++ b/pkg/cloudprovider/providers/vsphere/vsphere.go
@@ -35,7 +35,6 @@ import (
 	"golang.org/x/net/context"
 	"k8s.io/api/core/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/tools/cache"
 	v1helper "k8s.io/kubernetes/pkg/apis/core/v1/helper"
@@ -211,21 +210,23 @@ func init() {
 
 // Initialize passes a Kubernetes clientBuilder interface to the cloud provider
 func (vs *VSphere) Initialize(clientBuilder controller.ControllerClientBuilder) {
+}
+
+// Initialize Node Informers
+func (vs *VSphere) SetInformers(informerFactory informers.SharedInformerFactory) {
 	if vs.cfg == nil {
 		return
 	}
 
 	// Only on controller node it is required to register listeners.
 	// Register callbacks for node updates
-	client := clientBuilder.ClientOrDie("vsphere-cloud-provider")
-	factory := informers.NewSharedInformerFactory(client, 5*time.Minute)
-	nodeInformer := factory.Core().V1().Nodes()
-	nodeInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	glog.V(4).Infof("Setting up node informers for vSphere Cloud Provider")
+	nodeInformer := informerFactory.Core().V1().Nodes().Informer()
+	nodeInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    vs.NodeAdded,
 		DeleteFunc: vs.NodeDeleted,
 	})
-	go nodeInformer.Informer().Run(wait.NeverStop)
-	glog.V(4).Infof("vSphere cloud provider initialized")
+	glog.V(4).Infof("Node informers in vSphere cloud provider initialized")
 }
 
 // Creates new worker node interface and returns


### PR DESCRIPTION
In 1.9.2 release vSphere Cloud Provider needs a separate service account which is not needed.

In 1.9.0, 1.9.1 and 1.9.2,  vSphere Cloud Provider initialize method is creating Client with name "vsphere-cloud-provider". This client is used to create NodeInformer for registering callbacks for NodeEvents.
In reality creation of client is not needed. There is an Interface "SetInformers" if implemented by cloud provider gets the NodeInformer for use from Controller manager.
This is a change where SetInformers method is implemented in vSphere Cloud Provider to register callbacks for the NodeEvents.

Testing Done: Deployed Kubernetes cluster and checked the logs.
Below are the logs from controller manager:


{"log":"I0201 00:29:14.788619       1 vsphere.go:223] Setting up informers for vSphere Cloud Provider\n","stream":"stderr","time":"2018-02-01T00:29:14.788971834Z"}
{"log":"I0201 00:29:14.788753       1 vsphere.go:229] Informers in vSphere cloud provider initialized\n","stream":"stderr","time":"2018-02-01T00:29:14.788987799Z"}


{"log":"I0201 00:29:14.827790       1 vsphere.go:1148] Node added: \u0026Node{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:node1,GenerateName:,Namespace:,SelfLink:/api/v1/nodes/node1,UID:edc6f518-06e6-11e8-8a7d-005056b66ad1,ResourceVersion:14,Generation:0,CreationTimestamp:2018-02-01 00:29:13 +0000 UTC,DeletionTimestamp:\u003cnil\u003e,DeletionGracePeriodSeconds:nil,Labels:map[string]string{beta.kubernetes.io/arch: amd64,beta.kubernetes.io/os: linux,kubernetes.io/hostname: node1,},Annotations:map[string]string{volumes.kubernetes.io/controller-managed-attach-detach: true,},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Spec:NodeSpec{PodCIDR:,ExternalID:node1,ProviderID:vsphere://node1,Unschedulable:false,Taints:[],ConfigSource:nil,},Status:NodeStatus{Capacity:ResourceList{cpu: {{2 0} {\u003cnil\u003e} 2 DecimalSI},hugepages-2Mi: {{0 0} {\u003cnil\u003e} 0 DecimalSI},memory: {{4145516544 0} {\u003cnil\u003e} 4048356Ki BinarySI},pods: {{110 0} {\u003cnil\u003e} 110 DecimalSI},},Allocatable:ResourceList{cpu: {{2 0} {\u003cnil\u003e} 2 DecimalSI},hugepages-2Mi: {{0 0} {\u003cnil\u003e} 0 DecimalSI},memory: {{4040658944 0} {\u003cnil\u003e} 3945956Ki BinarySI},pods: {{110 0} {\u003cnil\u003e} 110 DecimalSI},},Phase:,Conditions:[{OutOfDisk False 2018-02-01 00:29:13 +0000 UTC 2018-02-01 00:29:11 +0000 UTC KubeletHasSufficientDisk kubelet has sufficient disk space available} {MemoryPressure False 2018-02-01 00:29:13 +0000 UTC 2018-02-01 00:29:11 +0000 UTC KubeletHasSufficientMemory kubelet has sufficient memory available} {DiskPressure False 2018-02-01 00:29:13 +0000 UTC 2018-02-01 00:29:11 +0000 UTC KubeletHasNoDiskPressure kubelet has no disk pressure} {Ready True 2018-02-01 00:29:13 +0000 UTC 2018-02-01 00:29:11 +0000 UTC KubeletReady kubelet is posting ready status}],Addresses:[{ExternalIP 10.192.104.3} {InternalIP 10.192.104.3} {Hostname node1}],DaemonEndpoints:NodeDaemonEndpoints{KubeletEndpoint:DaemonEndpoint{Port:10250,},},NodeInfo:NodeSystemInfo{MachineID:40beb5eb909e171860ceee669da56e1d,SystemUUID:423646A8-1086-7BF4-DA53-9BEF997445AA,BootID:e5e5cb19-ad39-4a02-903b-e0230ffc49a7,KernelVersion:4.4.8-esx,OSImage:Debian GNU/Linux 9 (stretch),ContainerRuntimeVersion:docker://1.11.0,KubeletVersion:v1.6.0-alpha.0.22256+5c75e0a40741ea,KubeProxyVersion:v1.6.0-alpha.0.22256+5c75e0a40741ea,OperatingSystem:linux,Architecture:amd64,},Images:[{[divyen/hyperkube-amd64:SetInformers-1] 622867069} {[cnastorage/k8s-ignition:v1.8-dev-release] 29620737}],VolumesInUse:[],VolumesAttached:[],},}\n","stream":"stderr","time":"2018-02-01T00:29:14.845059316Z"}

