### PR TITLE
Node delete (unregister) test to verify node discovery work flow

### DIFF
--- a/test/e2e/storage/vsphere/BUILD
+++ b/test/e2e/storage/vsphere/BUILD
@@ -28,6 +28,7 @@ go_library(
         "vsphere_volume_disksize.go",
         "vsphere_volume_fstype.go",
         "vsphere_volume_master_restart.go",
+        "vsphere_volume_node_delete.go",
         "vsphere_volume_node_poweroff.go",
         "vsphere_volume_ops_storm.go",
         "vsphere_volume_perf.go",

--- a/test/e2e/storage/vsphere/vsphere_utils.go
+++ b/test/e2e/storage/vsphere/vsphere_utils.go
@@ -23,6 +23,8 @@ import (
 	"time"
 
 	. "github.com/onsi/gomega"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/mo"
 	"k8s.io/api/core/v1"
 	storage "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -36,6 +38,11 @@ import (
 	"k8s.io/kubernetes/pkg/volume/util/volumehelper"
 	"k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/e2e/storage/utils"
+
+	"context"
+
+	"github.com/vmware/govmomi/find"
+	vimtypes "github.com/vmware/govmomi/vim25/types"
 )
 
 const (
@@ -466,4 +473,98 @@ func getVSphere(c clientset.Interface) (*vsphere.VSphere, error) {
 // GetVSphere returns vsphere cloud provider
 func GetVSphere(c clientset.Interface) (*vsphere.VSphere, error) {
 	return getVSphere(c)
+}
+
+// get .vmx file path for a virtual machine
+func getVMXFilePath(vmObject *object.VirtualMachine) (vmxPath string) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var nodeVM mo.VirtualMachine
+	err := vmObject.Properties(ctx, vmObject.Reference(), []string{"config.files"}, &nodeVM)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(nodeVM.Config).NotTo(BeNil())
+
+	vmxPath = nodeVM.Config.Files.VmPathName
+	framework.Logf("vmx file path is %s", vmxPath)
+	return vmxPath
+}
+
+// verify ready node count. Try upto 3 minutes. If count is expected count, return the nodeList
+func verifyReadyNodeCount(client clientset.Interface, expectedNodes int) (nodeList *v1.NodeList) {
+	numNodes := 0
+	for i := 0; i < 31; i++ {
+		nodeList = framework.GetReadySchedulableNodesOrDie(client)
+		Expect(nodeList.Items).NotTo(BeEmpty(), "Unable to find ready and schedulable Node")
+
+		numNodes = len(nodeList.Items)
+		if numNodes == expectedNodes {
+			break
+		}
+		time.Sleep(5 * time.Second)
+	}
+	Expect(numNodes).To(Equal(expectedNodes))
+	return nodeList
+}
+
+// poweroff nodeVM and confirm the poweroff state
+func poweroffNodeVM(nodeName string, vm *object.VirtualMachine) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	framework.Logf("Powering off node VM %s", nodeName)
+
+	_, err := vm.PowerOff(ctx)
+	Expect(err).NotTo(HaveOccurred())
+	err = vm.WaitForPowerState(ctx, vimtypes.VirtualMachinePowerStatePoweredOff)
+	Expect(err).NotTo(HaveOccurred(), "Unable to power off the node")
+}
+
+// poweron nodeVM and confirm the poweron state
+func poweronNodeVM(nodeName string, vm *object.VirtualMachine) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	framework.Logf("Powering on node VM %s", nodeName)
+
+	vm.PowerOn(ctx)
+	err := vm.WaitForPowerState(ctx, vimtypes.VirtualMachinePowerStatePoweredOn)
+	Expect(err).NotTo(HaveOccurred(), "Unable to power on the node")
+}
+
+// unregister a nodeVM from VC
+func unregisterNodeVM(nodeName string, vm *object.VirtualMachine) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	poweroffNodeVM(nodeName, vm)
+
+	framework.Logf("Unregistering node VM %s", nodeName)
+	err := vm.Unregister(ctx)
+	Expect(err).NotTo(HaveOccurred(), "Unable to unregister the node")
+}
+
+// register a nodeVM into a VC
+func registerNodeVM(nodeName, workingDir, vmxFilePath string, rpool *object.ResourcePool, host *object.HostSystem) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	framework.Logf("Registering node VM %s", nodeName)
+
+	nodeInfo := TestContext.NodeMapper.GetNodeInfo(nodeName)
+	finder := find.NewFinder(nodeInfo.VSphere.Client.Client, true)
+
+	vmFolder, err := finder.FolderOrDefault(ctx, workingDir)
+	Expect(err).NotTo(HaveOccurred())
+
+	registerTask, err := vmFolder.RegisterVM(ctx, vmxFilePath, nodeName, false, rpool, host)
+	Expect(err).NotTo(HaveOccurred())
+	err = registerTask.Wait(ctx)
+	Expect(err).NotTo(HaveOccurred())
+
+	vmPath := filepath.Join(workingDir, nodeName)
+	vm, err := finder.VirtualMachine(ctx, vmPath)
+	Expect(err).NotTo(HaveOccurred())
+
+	poweronNodeVM(nodeName, vm)
 }

--- a/test/e2e/storage/vsphere/vsphere_utils.go
+++ b/test/e2e/storage/vsphere/vsphere_utils.go
@@ -490,11 +490,11 @@ func getVMXFilePath(vmObject *object.VirtualMachine) (vmxPath string) {
 	return vmxPath
 }
 
-// verify ready node count. Try upto 3 minutes. If count is expected count, return the nodeList
-func verifyReadyNodeCount(client clientset.Interface, expectedNodes int) (nodeList *v1.NodeList) {
+// verify ready node count. Try upto 3 minutes. Return true if count is expected count
+func verifyReadyNodeCount(client clientset.Interface, expectedNodes int) bool {
 	numNodes := 0
-	for i := 0; i < 31; i++ {
-		nodeList = framework.GetReadySchedulableNodesOrDie(client)
+	for i := 0; i < 36; i++ {
+		nodeList := framework.GetReadySchedulableNodesOrDie(client)
 		Expect(nodeList.Items).NotTo(BeEmpty(), "Unable to find ready and schedulable Node")
 
 		numNodes = len(nodeList.Items)
@@ -503,8 +503,7 @@ func verifyReadyNodeCount(client clientset.Interface, expectedNodes int) (nodeLi
 		}
 		time.Sleep(5 * time.Second)
 	}
-	Expect(numNodes).To(Equal(expectedNodes))
-	return nodeList
+	return (numNodes == expectedNodes)
 }
 
 // poweroff nodeVM and confirm the poweroff state
@@ -549,7 +548,7 @@ func registerNodeVM(nodeName, workingDir, vmxFilePath string, rpool *object.Reso
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	framework.Logf("Registering node VM %s", nodeName)
+	framework.Logf("Registering node VM %s with vmx file path %s", nodeName, vmxFilePath)
 
 	nodeInfo := TestContext.NodeMapper.GetNodeInfo(nodeName)
 	finder := find.NewFinder(nodeInfo.VSphere.Client.Client, true)

--- a/test/e2e/storage/vsphere/vsphere_volume_node_delete.go
+++ b/test/e2e/storage/vsphere/vsphere_volume_node_delete.go
@@ -53,7 +53,6 @@ var _ = utils.SIGDescribe("Node Unregister [Feature:vsphere] [Slow] [Disruptive]
 	It("node unregister", func() {
 		By("Get total Ready nodes")
 		nodeList := framework.GetReadySchedulableNodesOrDie(f.ClientSet)
-		Expect(nodeList.Items).NotTo(BeEmpty(), "Unable to find ready and schedulable Node")
 		Expect(len(nodeList.Items) > 1).To(BeTrue(), "At least 2 nodes are required for this test")
 
 		totalNodesCount := len(nodeList.Items)
@@ -81,7 +80,11 @@ var _ = utils.SIGDescribe("Node Unregister [Feature:vsphere] [Slow] [Disruptive]
 
 		// Ready nodes should be 1 less
 		By("Verifying the ready node counts")
-		nodeList = verifyReadyNodeCount(f.ClientSet, totalNodesCount-1)
+		Expect(verifyReadyNodeCount(f.ClientSet, totalNodesCount-1)).To(BeTrue(), "Unable to verify expected ready node count")
+
+		nodeList = framework.GetReadySchedulableNodesOrDie(client)
+		Expect(nodeList.Items).NotTo(BeEmpty(), "Unable to find ready and schedulable Node")
+
 		var nodeNameList []string
 		for _, node := range nodeList.Items {
 			nodeNameList = append(nodeNameList, node.ObjectMeta.Name)
@@ -94,7 +97,11 @@ var _ = utils.SIGDescribe("Node Unregister [Feature:vsphere] [Slow] [Disruptive]
 
 		// Ready nodes should be equal to earlier count
 		By("Verifying the ready node counts")
-		nodeList = verifyReadyNodeCount(f.ClientSet, totalNodesCount)
+		Expect(verifyReadyNodeCount(f.ClientSet, totalNodesCount)).To(BeTrue(), "Unable to verify expected ready node count")
+
+		nodeList = framework.GetReadySchedulableNodesOrDie(client)
+		Expect(nodeList.Items).NotTo(BeEmpty(), "Unable to find ready and schedulable Node")
+
 		nodeNameList = nodeNameList[:0]
 		for _, node := range nodeList.Items {
 			nodeNameList = append(nodeNameList, node.ObjectMeta.Name)

--- a/test/e2e/storage/vsphere/vsphere_volume_node_delete.go
+++ b/test/e2e/storage/vsphere/vsphere_volume_node_delete.go
@@ -1,0 +1,112 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vsphere
+
+import (
+	"os"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/vmware/govmomi/object"
+	"golang.org/x/net/context"
+
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/test/e2e/framework"
+	"k8s.io/kubernetes/test/e2e/storage/utils"
+)
+
+var _ = utils.SIGDescribe("Node Unregister [Feature:vsphere] [Slow] [Disruptive]", func() {
+	f := framework.NewDefaultFramework("node-unregister")
+	var (
+		client     clientset.Interface
+		namespace  string
+		workingDir string
+		err        error
+	)
+
+	BeforeEach(func() {
+		framework.SkipUnlessProviderIs("vsphere")
+		Bootstrap(f)
+		client = f.ClientSet
+		namespace = f.Namespace.Name
+		framework.ExpectNoError(framework.WaitForAllNodesSchedulable(client, framework.TestContext.NodeSchedulableTimeout))
+		Expect(err).NotTo(HaveOccurred())
+		workingDir = os.Getenv("VSPHERE_WORKING_DIR")
+		Expect(workingDir).NotTo(BeEmpty())
+
+	})
+
+	It("node unregister", func() {
+		By("Get total Ready nodes")
+		nodeList := framework.GetReadySchedulableNodesOrDie(f.ClientSet)
+		Expect(nodeList.Items).NotTo(BeEmpty(), "Unable to find ready and schedulable Node")
+		Expect(len(nodeList.Items) > 1).To(BeTrue(), "At least 2 nodes are required for this test")
+
+		totalNodesCount := len(nodeList.Items)
+		nodeVM := nodeList.Items[0]
+
+		nodeInfo := TestContext.NodeMapper.GetNodeInfo(nodeVM.ObjectMeta.Name)
+		vmObject := object.NewVirtualMachine(nodeInfo.VSphere.Client.Client, nodeInfo.VirtualMachineRef)
+
+		// Find VM .vmx file path, host, resource pool.
+		// They are required to register a node VM to VC
+		vmxFilePath := getVMXFilePath(vmObject)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		vmHost, err := vmObject.HostSystem(ctx)
+		Expect(err).NotTo(HaveOccurred())
+
+		vmPool, err := vmObject.ResourcePool(ctx)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Unregister Node VM
+		By("Unregister a node VM")
+		unregisterNodeVM(nodeVM.ObjectMeta.Name, vmObject)
+
+		// Ready nodes should be 1 less
+		By("Verifying the ready node counts")
+		nodeList = verifyReadyNodeCount(f.ClientSet, totalNodesCount-1)
+		var nodeNameList []string
+		for _, node := range nodeList.Items {
+			nodeNameList = append(nodeNameList, node.ObjectMeta.Name)
+		}
+		Expect(nodeNameList).NotTo(ContainElement(nodeVM.ObjectMeta.Name))
+
+		// Register Node VM
+		By("Register back the node VM")
+		registerNodeVM(nodeVM.ObjectMeta.Name, workingDir, vmxFilePath, vmPool, vmHost)
+
+		// Ready nodes should be equal to earlier count
+		By("Verifying the ready node counts")
+		nodeList = verifyReadyNodeCount(f.ClientSet, totalNodesCount)
+		nodeNameList = nodeNameList[:0]
+		for _, node := range nodeList.Items {
+			nodeNameList = append(nodeNameList, node.ObjectMeta.Name)
+		}
+		Expect(nodeNameList).To(ContainElement(nodeVM.ObjectMeta.Name))
+
+		// Sanity test that pod provisioning works
+		By("Sanity check for volume lifecycle")
+		scParameters := make(map[string]string)
+		storagePolicy := os.Getenv("VSPHERE_SPBM_GOLD_POLICY")
+		Expect(storagePolicy).NotTo(BeEmpty(), "Please set VSPHERE_SPBM_GOLD_POLICY system environment")
+		scParameters[SpbmStoragePolicy] = storagePolicy
+		invokeValidPolicyTest(f, client, namespace, scParameters)
+	})
+})


### PR DESCRIPTION
Fixes #379 

```
bash-3.2$ go run hack/e2e.go --check-version-skew=false --v --test --test_args='--ginkgo.focus=Node\sUnregister'
flag provided but not defined: -check-version-skew
Usage of /var/folders/97/lnlv1n317xl2ty8hdn7zptxr00b37m/T/go-build743103230/command-line-arguments/_obj/exe/e2e:
  -get
    	go get -u kubetest if old or not installed (default true)
  -old duration
    	Consider kubetest old if it exceeds this (default 24h0m0s)
2018/02/05 22:20:08 e2e.go:55: NOTICE: go run hack/e2e.go is now a shim for test-infra/kubetest
2018/02/05 22:20:08 e2e.go:56:   Usage: go run hack/e2e.go [--get=true] [--old=24h0m0s] -- [KUBETEST_ARGS]
2018/02/05 22:20:08 e2e.go:57:   The separator is required to use --get or --old flags
2018/02/05 22:20:08 e2e.go:58:   The -- flag separator also suppresses this message
2018/02/05 22:20:08 e2e.go:77: Calling kubetest --check-version-skew=false --v --test --test_args=--ginkgo.focus=Node\sUnregister...
2018/02/05 22:20:08 util.go:172: Running: ./cluster/kubectl.sh --match-server-version=false version
2018/02/05 22:20:08 util.go:174: Step './cluster/kubectl.sh --match-server-version=false version' finished in 348.709516ms
2018/02/05 22:20:08 util.go:172: Running: ./hack/e2e-internal/e2e-status.sh
Skeleton Provider: prepare-e2e not implemented
Client Version: version.Info{Major:"1", Minor:"6+", GitVersion:"v1.6.0-alpha.0.22495+6cd18f22c2ba64-dirty", GitCommit:"6cd18f22c2ba64febc195ee9fe1cfa2c49681b30", GitTreeState:"dirty", BuildDate:"2018-02-05T22:13:53Z", GoVersion:"go1.9.2", Compiler:"gc", Platform:"darwin/amd64"}
Server Version: version.Info{Major:"1", Minor:"9", GitVersion:"v1.9.2", GitCommit:"5fa2db2bd46ac79e5e00a4e6ed24191080aa463b", GitTreeState:"clean", BuildDate:"2018-01-18T09:42:01Z", GoVersion:"go1.9.2", Compiler:"gc", Platform:"linux/amd64"}
2018/02/05 22:20:08 util.go:174: Step './hack/e2e-internal/e2e-status.sh' finished in 240.551543ms
2018/02/05 22:20:08 util.go:172: Running: ./hack/ginkgo-e2e.sh --ginkgo.focus=Node\sUnregister
Conformance test: not doing test setup.
Feb  5 22:20:09.734: INFO: Overriding default scale value of zero to 1
Feb  5 22:20:09.735: INFO: Overriding default milliseconds value of zero to 5000
I0205 22:20:09.867001   42395 e2e.go:331] Starting e2e run "c8318e68-0b05-11e8-add7-784f435ee632" on Ginkgo node 1
Running Suite: Kubernetes e2e suite
===================================
Random Seed: 1517898009 - Will randomize all specs
Will run 1 of 724 specs

Feb  5 22:20:09.890: INFO: >>> kubeConfig: /Users/pshahzeb/kube176.json
Feb  5 22:20:09.903: INFO: Waiting up to 4h0m0s for all (but 0) nodes to be schedulable
Feb  5 22:20:10.036: INFO: Waiting up to 10m0s for all pods (need at least 0) in namespace 'kube-system' to be running and ready
Feb  5 22:20:10.182: INFO: 13 / 13 pods in namespace 'kube-system' are running and ready (0 seconds elapsed)
Feb  5 22:20:10.182: INFO: expected 4 pod replicas in namespace 'kube-system', 4 are Running and Ready.
Feb  5 22:20:10.203: INFO: Waiting for pods to enter Success, but no pods in "kube-system" match label map[name:e2e-image-puller]
Feb  5 22:20:10.203: INFO: Dumping network health container logs from all nodes...
Feb  5 22:20:10.236: INFO: e2e test version: v1.6.0-alpha.0.22494+e66916e052163a-dirty
Feb  5 22:20:10.261: INFO: kube-apiserver version: v1.9.2
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
------------------------------
[sig-storage] Node Unregister [Feature:vsphere] [Slow] [Disruptive]
  node unregister
  /Users/pshahzeb/k8s/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/storage/vsphere/vsphere_volume_node_delete.go:53
[BeforeEach] [sig-storage] Node Unregister [Feature:vsphere] [Slow] [Disruptive]
  /Users/pshahzeb/k8s/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
STEP: Creating a kubernetes client
Feb  5 22:20:10.268: INFO: >>> kubeConfig: /Users/pshahzeb/kube176.json
STEP: Building a namespace api object
Feb  5 22:20:11.043: INFO: No PodSecurityPolicies found; assuming PodSecurityPolicy is disabled.
STEP: Waiting for a default service account to be provisioned in namespace
[BeforeEach] [sig-storage] Node Unregister [Feature:vsphere] [Slow] [Disruptive]
  /Users/pshahzeb/k8s/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/storage/vsphere/vsphere_volume_node_delete.go:41
Feb  5 22:20:11.063: INFO: Initializing vc server 10.160.240.176
Feb  5 22:20:11.063: INFO: ConfigFile &{{administrator@vsphere.local Admin!23 443 true k8s-dc 0} map[10.160.240.176:0xc420babe30] {VM Network} {pvscsi} {10.160.240.176 k8s-dc kubernetes vsanDatastore k8s-cluster}}
 vSphere instances map[10.160.240.176:0xc420b08830]
Feb  5 22:20:11.331: INFO: Search candidates vc=10.160.240.176 and datacenter=k8s-dc
Feb  5 22:20:11.332: INFO: Searching for node with UUID: 4200EDCD-05D8-FC9F-3B47-DF53163317C3
Feb  5 22:20:11.332: INFO: Searching for node with UUID: 42002A28-9E6D-D6F2-F7E7-028DFA500BDD
Feb  5 22:20:11.332: INFO: Searching for node with UUID: 4200BC3A-56B6-FFEB-E937-CA86D759E42C
Feb  5 22:20:11.332: INFO: Searching for node with UUID: 564DE2F7-DABD-61FA-00ED-9E4347E26715
Feb  5 22:20:11.404: INFO: Found node kubernetes-node4 as vm=VirtualMachine:vm-142 in vc=10.160.240.176 and datacenter=k8s-dc
Feb  5 22:20:11.429: INFO: Found node kubernetes-node2 as vm=VirtualMachine:vm-140 in vc=10.160.240.176 and datacenter=k8s-dc
Feb  5 22:20:11.459: INFO: Found node kubernetes-node3 as vm=VirtualMachine:vm-141 in vc=10.160.240.176 and datacenter=k8s-dc
Feb  5 22:20:11.480: INFO: Found node kubernetes-node1 as vm=VirtualMachine:vm-153 in vc=10.160.240.176 and datacenter=k8s-dc
Feb  5 22:20:11.480: INFO: Waiting up to 4h0m0s for all (but 0) nodes to be schedulable
[It] node unregister
  /Users/pshahzeb/k8s/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/storage/vsphere/vsphere_volume_node_delete.go:53
STEP: Get total Ready nodes
Feb  5 22:20:11.566: INFO: vmx file path is [vsanDatastore] 2e98735a-cdb9-c3f3-63d8-020010188a6a/kubernetes-node1.vmx
STEP: Unregister a node VM
Feb  5 22:20:11.686: INFO: Powering off node VM kubernetes-node1
Feb  5 22:20:14.148: INFO: Unregistering node VM kubernetes-node1
STEP: Verifying the ready node counts
STEP: Register back the node VM
Feb  5 22:20:49.490: INFO: Registering node VM kubernetes-node1
Feb  5 22:20:51.785: INFO: Powering on node VM kubernetes-node1
STEP: Verifying the ready node counts
Feb  5 22:21:40.600: INFO: Condition Ready of node kubernetes-node1 is false instead of true. Reason: KubeletNotReady, message: container runtime is down
Feb  5 22:21:45.625: INFO: Condition Ready of node kubernetes-node1 is false instead of true. Reason: KubeletNotReady, message: container runtime is down
STEP: Sanity check for volume lifecycle
STEP: Creating Storage Class With storage policy params
STEP: Creating PVC using the Storage Class
STEP: Waiting for claim to be in bound phase
Feb  5 22:21:50.718: INFO: Waiting up to 5m0s for PersistentVolumeClaim pvc-ztj7g to have phase Bound
Feb  5 22:21:50.753: INFO: PersistentVolumeClaim pvc-ztj7g found but phase is Pending instead of Bound.
Feb  5 22:21:52.773: INFO: PersistentVolumeClaim pvc-ztj7g found but phase is Pending instead of Bound.
Feb  5 22:21:54.798: INFO: PersistentVolumeClaim pvc-ztj7g found but phase is Pending instead of Bound.
Feb  5 22:21:56.819: INFO: PersistentVolumeClaim pvc-ztj7g found but phase is Pending instead of Bound.
Feb  5 22:21:58.846: INFO: PersistentVolumeClaim pvc-ztj7g found but phase is Pending instead of Bound.
Feb  5 22:22:00.889: INFO: PersistentVolumeClaim pvc-ztj7g found but phase is Pending instead of Bound.
Feb  5 22:22:02.917: INFO: PersistentVolumeClaim pvc-ztj7g found but phase is Pending instead of Bound.
Feb  5 22:22:04.937: INFO: PersistentVolumeClaim pvc-ztj7g found but phase is Pending instead of Bound.
Feb  5 22:22:06.960: INFO: PersistentVolumeClaim pvc-ztj7g found but phase is Pending instead of Bound.
Feb  5 22:22:08.987: INFO: PersistentVolumeClaim pvc-ztj7g found but phase is Pending instead of Bound.
Feb  5 22:22:11.011: INFO: PersistentVolumeClaim pvc-ztj7g found but phase is Pending instead of Bound.
Feb  5 22:22:13.034: INFO: PersistentVolumeClaim pvc-ztj7g found but phase is Pending instead of Bound.
Feb  5 22:22:15.053: INFO: PersistentVolumeClaim pvc-ztj7g found and phase=Bound (24.334875493s)
STEP: Creating pod to attach PV to the node
STEP: Verify the volume is accessible and available in the pod
Feb  5 22:22:25.976: INFO: Running '/Users/pshahzeb/k8s/kubernetes/_output/bin/kubectl --server=https://10.160.241.49 --kubeconfig=/Users/pshahzeb/kube176.json exec pvc-tester-q7q2w --namespace=e2e-tests-node-unregister-csdrc -- /bin/touch /mnt/volume1/emptyFile.txt'
Feb  5 22:22:26.740: INFO: stderr: ""
Feb  5 22:22:26.740: INFO: stdout: ""
STEP: Deleting pod
Feb  5 22:22:26.740: INFO: Deleting pod "pvc-tester-q7q2w" in namespace "e2e-tests-node-unregister-csdrc"
Feb  5 22:22:26.799: INFO: Wait up to 5m0s for pod "pvc-tester-q7q2w" to be fully deleted
STEP: Waiting for volumes to be detached from the node
Feb  5 22:23:16.966: INFO: Volume "[vsanDatastore] f0c55f5a-7349-1aad-2464-02001067f24e/kubernetes-dynamic-pvc-04775fe5-0b06-11e8-9872-005056809c8d.vmdk" has successfully detached from "kubernetes-node1"
Feb  5 22:23:16.966: INFO: Deleting PersistentVolumeClaim "pvc-ztj7g"
[AfterEach] [sig-storage] Node Unregister [Feature:vsphere] [Slow] [Disruptive]
  /Users/pshahzeb/k8s/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
Feb  5 22:23:17.026: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
STEP: Destroying namespace "e2e-tests-node-unregister-csdrc" for this suite.
Feb  5 22:23:23.158: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
Feb  5 22:23:24.421: INFO: namespace: e2e-tests-node-unregister-csdrc, resource: bindings, ignored listing per whitelist
Feb  5 22:23:24.795: INFO: namespace e2e-tests-node-unregister-csdrc deletion completed in 7.715803086s

• [SLOW TEST:194.521 seconds]
[sig-storage] Node Unregister [Feature:vsphere] [Slow] [Disruptive]
/Users/pshahzeb/k8s/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/storage/utils/framework.go:22
  node unregister
  /Users/pshahzeb/k8s/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/storage/vsphere/vsphere_volume_node_delete.go:53
------------------------------
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSFeb  5 22:23:24.797: INFO: Running AfterSuite actions on all node
Feb  5 22:23:24.798: INFO: Running AfterSuite actions on node 1

Ran 1 of 724 Specs in 194.905 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 723 Skipped PASS

Ginkgo ran 1 suite in 3m15.529747133s
Test Suite Passed
2018/02/05 22:23:24 util.go:174: Step './hack/ginkgo-e2e.sh --ginkgo.focus=Node\sUnregister' finished in 3m16.095671615s
2018/02/05 22:23:24 e2e.go:81: Done
```