### PR TITLE
Adds e2e test for VMware vpxd restart scenario

### DIFF
--- a/test/e2e/storage/vsphere/vsphere_utils.go
+++ b/test/e2e/storage/vsphere/vsphere_utils.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/golang/glog"
+	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/vmware/govmomi/object"
 
@@ -373,7 +374,7 @@ func getVSpherePodSpecWithVolumePaths(volumePaths []string, keyValuelabel map[st
 	return pod
 }
 
-func verifyFilesExistOnVSphereVolume(namespace string, podName string, filePaths []string) {
+func verifyFilesExistOnVSphereVolume(namespace string, podName string, filePaths ...string) {
 	for _, filePath := range filePaths {
 		_, err := framework.RunKubectl("exec", fmt.Sprintf("--namespace=%s", namespace), podName, "--", "/bin/ls", filePath)
 		Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("failed to verify file: %q on the pod: %q", filePath, podName))
@@ -754,4 +755,73 @@ func GetReadySchedulableRandomNodeInfo() *NodeInfo {
 	rand.Seed(time.Now().Unix())
 	Expect(nodesInfo).NotTo(BeEmpty())
 	return nodesInfo[rand.Int()%len(nodesInfo)]
+}
+
+// InvokeVCenterServiceControl invokes the given command for the given service
+// via service-control on the given vCenter host over SSH.
+func InvokeVCenterServiceControl(command, service, host string) error {
+	sshCmd := fmt.Sprintf("service-control --%s %s", command, service)
+	framework.Logf("Invoking command %v on vCenter host %v", sshCmd, host)
+	result, err := framework.SSH(sshCmd, host, framework.TestContext.Provider)
+	if err != nil || result.Code != 0 {
+		framework.LogSSHResult(result)
+		return fmt.Errorf("couldn't execute command: %s on vCenter host: %v", sshCmd, err)
+	}
+	return nil
+}
+
+// expectVolumeToBeAttached checks if the given Volume is attached to the given
+// Node, else fails.
+func expectVolumeToBeAttached(nodeName, volumePath string) {
+	isAttached, err := diskIsAttached(volumePath, nodeName)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(isAttached).To(BeTrue(), fmt.Sprintf("disk: %s is not attached with the node", volumePath))
+}
+
+// expectVolumesToBeAttached checks if the given Volumes are attached to the
+// corresponding set of Nodes, else fails.
+func expectVolumesToBeAttached(pods []*v1.Pod, volumePaths []string) {
+	for i, pod := range pods {
+		nodeName := pod.Spec.NodeName
+		volumePath := volumePaths[i]
+		By(fmt.Sprintf("Verifying that volume %v is attached to node %v", volumePath, nodeName))
+		expectVolumeToBeAttached(nodeName, volumePath)
+	}
+}
+
+// expectFilesToBeAccessible checks if the given files are accessible on the
+// corresponding set of Nodes, else fails.
+func expectFilesToBeAccessible(namespace string, pods []*v1.Pod, filePaths []string) {
+	for i, pod := range pods {
+		podName := pod.Name
+		filePath := filePaths[i]
+		By(fmt.Sprintf("Verifying that file %v is accessible on pod %v", filePath, podName))
+		verifyFilesExistOnVSphereVolume(namespace, podName, filePath)
+	}
+}
+
+// writeContentToPodFile writes the given content to the specified file.
+func writeContentToPodFile(namespace, podName, filePath, content string) error {
+	_, err := framework.RunKubectl("exec", fmt.Sprintf("--namespace=%s", namespace), podName,
+					"--", "/bin/sh", "-c", fmt.Sprintf("echo '%s' > %s", content, filePath))
+	return err
+}
+
+// expectFileContentToMatch checks if a given file contains the specified
+// content, else fails.
+func expectFileContentToMatch(namespace, podName, filePath, content string) {
+	_, err := framework.RunKubectl("exec", fmt.Sprintf("--namespace=%s", namespace), podName,
+					"--", "/bin/sh", "-c", fmt.Sprintf("grep '%s' %s", content, filePath))
+	Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("failed to match content of file: %q on the pod: %q", filePath, podName))
+}
+
+// expectFileContentsToMatch checks if the given contents match the ones present
+// in corresponding files on respective Pods, else fails.
+func expectFileContentsToMatch(namespace string, pods []*v1.Pod, filePaths []string, contents []string) {
+	for i, pod := range pods {
+		podName := pod.Name
+		filePath := filePaths[i]
+		By(fmt.Sprintf("Matching file content for %v on pod %v", filePath, podName))
+		expectFileContentToMatch(namespace, podName, filePath, contents[i])
+	}
 }

--- a/test/e2e/storage/vsphere/vsphere_utils.go
+++ b/test/e2e/storage/vsphere/vsphere_utils.go
@@ -757,9 +757,9 @@ func GetReadySchedulableRandomNodeInfo() *NodeInfo {
 	return nodesInfo[rand.Int()%len(nodesInfo)]
 }
 
-// InvokeVCenterServiceControl invokes the given command for the given service
+// invokeVCenterServiceControl invokes the given command for the given service
 // via service-control on the given vCenter host over SSH.
-func InvokeVCenterServiceControl(command, service, host string) error {
+func invokeVCenterServiceControl(command, service, host string) error {
 	sshCmd := fmt.Sprintf("service-control --%s %s", command, service)
 	framework.Logf("Invoking command %v on vCenter host %v", sshCmd, host)
 	result, err := framework.SSH(sshCmd, host, framework.TestContext.Provider)
@@ -803,7 +803,7 @@ func expectFilesToBeAccessible(namespace string, pods []*v1.Pod, filePaths []str
 // writeContentToPodFile writes the given content to the specified file.
 func writeContentToPodFile(namespace, podName, filePath, content string) error {
 	_, err := framework.RunKubectl("exec", fmt.Sprintf("--namespace=%s", namespace), podName,
-					"--", "/bin/sh", "-c", fmt.Sprintf("echo '%s' > %s", content, filePath))
+		"--", "/bin/sh", "-c", fmt.Sprintf("echo '%s' > %s", content, filePath))
 	return err
 }
 
@@ -811,7 +811,7 @@ func writeContentToPodFile(namespace, podName, filePath, content string) error {
 // content, else fails.
 func expectFileContentToMatch(namespace, podName, filePath, content string) {
 	_, err := framework.RunKubectl("exec", fmt.Sprintf("--namespace=%s", namespace), podName,
-					"--", "/bin/sh", "-c", fmt.Sprintf("grep '%s' %s", content, filePath))
+		"--", "/bin/sh", "-c", fmt.Sprintf("grep '%s' %s", content, filePath))
 	Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("failed to match content of file: %q on the pod: %q", filePath, podName))
 }
 

--- a/test/e2e/storage/vsphere/vsphere_volume_cluster_ds.go
+++ b/test/e2e/storage/vsphere/vsphere_volume_cluster_ds.go
@@ -17,7 +17,6 @@ limitations under the License.
 package vsphere
 
 import (
-	"fmt"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -98,9 +97,7 @@ var _ = utils.SIGDescribe("Volume Provisioning On Clustered Datastore [Feature:v
 		nodeName := pod.Spec.NodeName
 
 		By("Verifying volume is attached")
-		isAttached, err := diskIsAttached(volumePath, nodeName)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(isAttached).To(BeTrue(), fmt.Sprintf("disk: %s is not attached with the node: %v", volumePath, nodeName))
+		expectVolumeToBeAttached(nodeName, volumePath)
 
 		By("Deleting pod")
 		err = framework.DeletePodWithWait(f, client, pod)

--- a/test/e2e/storage/vsphere/vsphere_volume_placement.go
+++ b/test/e2e/storage/vsphere/vsphere_volume_placement.go
@@ -320,9 +320,9 @@ var _ = utils.SIGDescribe("Volume Placement", func() {
 
 			// Verify newly and previously created files present on the volume mounted on the pod
 			By("Verify newly Created file and previously created files present on volume mounted on pod-A")
-			verifyFilesExistOnVSphereVolume(ns, podA.Name, podAFiles)
+			verifyFilesExistOnVSphereVolume(ns, podA.Name, podAFiles...)
 			By("Verify newly Created file and previously created files present on volume mounted on pod-B")
-			verifyFilesExistOnVSphereVolume(ns, podB.Name, podBFiles)
+			verifyFilesExistOnVSphereVolume(ns, podB.Name, podBFiles...)
 
 			By("Deleting pod-A")
 			framework.ExpectNoError(framework.DeletePodWithWait(f, c, podA), "Failed to delete pod ", podA.Name)
@@ -378,7 +378,7 @@ func createAndVerifyFilesOnVolume(namespace string, podname string, newEmptyfile
 
 	// Verify newly and previously created files present on the volume mounted on the pod
 	By(fmt.Sprintf("Verify newly Created file and previously created files present on volume mounted on: %v", podname))
-	verifyFilesExistOnVSphereVolume(namespace, podname, filesToCheck)
+	verifyFilesExistOnVSphereVolume(namespace, podname, filesToCheck...)
 }
 
 func deletePodAndWaitForVolumeToDetach(f *framework.Framework, c clientset.Interface, pod *v1.Pod, nodeName string, volumePaths []string) {

--- a/test/e2e/storage/vsphere/vsphere_volume_vpxd_restart.go
+++ b/test/e2e/storage/vsphere/vsphere_volume_vpxd_restart.go
@@ -132,14 +132,14 @@ var _ = utils.SIGDescribe("Verify Volume Attach Through vpxd Restart [Feature:vs
 
 		By("Stopping vpxd on the vCenter host")
 		vcAddress := vcHost + ":22"
-		err := InvokeVCenterServiceControl("stop", vpxdServiceName, vcAddress)
+		err := invokeVCenterServiceControl("stop", vpxdServiceName, vcAddress)
 		Expect(err).NotTo(HaveOccurred(), "Unable to stop vpxd on the vCenter host")
 
 		expectFilesToBeAccessible(namespace, pods, filePaths)
 		expectFileContentsToMatch(namespace, pods, filePaths, fileContents)
 
 		By("Starting vpxd on the vCenter host")
-		err = InvokeVCenterServiceControl("start", vpxdServiceName, vcAddress)
+		err = invokeVCenterServiceControl("start", vpxdServiceName, vcAddress)
 		Expect(err).NotTo(HaveOccurred(), "Unable to start vpxd on the vCenter host")
 
 		expectVolumesToBeAttached(pods, volumePaths)

--- a/test/e2e/storage/vsphere/vsphere_volume_vpxd_restart.go
+++ b/test/e2e/storage/vsphere/vsphere_volume_vpxd_restart.go
@@ -57,7 +57,7 @@ var _ = utils.SIGDescribe("Verify Volume Attach Through vpxd Restart [Feature:vs
 	}
 
 	const (
-		labelKey        = "vsphere_e2e_label"
+		labelKey        = "vsphere_e2e_label_vpxd_restart"
 		vpxdServiceName = "vmware-vpxd"
 	)
 


### PR DESCRIPTION
This PR adds a test to verify Volume access in a situation where VMware vCenter's `vpxd` service is down. The test mainly verifies Volume/file access before, during, and after restarting the `vpxd` service on the vCenter host. See #373 for more information.

**Prerequisites**
The public key of the machine executing the test needs to be added to the `/root/.ssh/authorized_keys` file on the VMware vCenter host.

**Test Output**
Following is the output snippet from `go run hack/e2e.go --check-version-skew=false -v 10 --test --test_args="--ginkgo.focus=Verify\sVolume\sAttach\sThrough\svpxd\sRestart"`.

```
Mar 13 17:11:12.539: INFO: Running AfterSuite actions on all node
Mar 13 17:11:12.540: INFO: Running AfterSuite actions on node 1

Ran 1 of 745 Specs in 204.968 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 744 Skipped PASS

Ginkgo ran 1 suite in 3m25.503975536s
Test Suite Passed
2018/03/13 17:11:12 process.go:152: Step './hack/ginkgo-e2e.sh --ginkgo.focus=Verify\sVolume\sAttach\sThrough\svpxd\sRestart' finished in 3m25.865649618s
2018/03/13 17:11:12 e2e.go:81: Done
```

Please review.

Thanks,
Venil