### PR TITLE
Add a toleration to avoid removing the taint on the master nodes

### DIFF
--- a/enable-vcp-image/enable-vcp-scripts/vcp-daemontset.yaml
+++ b/enable-vcp-image/enable-vcp-scripts/vcp-daemontset.yaml
@@ -39,6 +39,9 @@ spec:
           mountPath: /secret-volume
           readOnly: true
       hostNetwork: true
+      tolerations:
+        - effect: NoSchedule
+          operator: Exists
       volumes:
         - name: rootpath
           hostPath:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Add a toleration to the daemonset to allow scheduling of the pods without removing the taint on the master nodes.

With this toleration, you don't need to do "kubectl taint nodes --all node-role.kubernetes.io/master-" as described in the README:

https://github.com/vmware/kubernetes/blob/enable-vcp-uxi/README.md

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
