### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ Following are the Prerequisites for this automation.
 
  * We need a vCenter admin username and password.
  * Separate user for vSphere Cloud Provider needs to be pre-created on the vCenter. This Step is optional but recommended.
- * Daemonset Pods should be allowed to be scheduled on all nodes. If Kubernetes is deployed using kubeadm, we see the taint ```node-role.kubernetes.io/master``` on the master node. Make sure to remove this taint. Taint can be removed using the following command.
 
-    ```kubectl taint nodes --all node-role.kubernetes.io/master-```
+
+
 
 
 Let's get started with how to use these automation scripts.


### PR DESCRIPTION
Updating Prerequisites for enable-vcp-uxi automation.

vcp-daemontset.yaml is updated with PR: https://github.com/vmware/kubernetes/pull/478. 

We don't need to do "kubectl taint nodes --all node-role.kubernetes.io/master-" to allow scheduling of the pods on the master nodes with taint. So removing step for removing taint from the prerequisites.

**Preview of change**: https://github.com/vmware/kubernetes/blob/4adeccf40eb01be6b8ad47a908b9717384ef4b32/README.md

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
