### PR TITLE
Provision vsphere volumes as per zone and attach labels

### DIFF
--- a/pkg/cloudprovider/providers/vsphere/vclib/datacenter.go
+++ b/pkg/cloudprovider/providers/vsphere/vclib/datacenter.go
@@ -145,6 +145,20 @@ func (dc *Datacenter) GetAllDatastores(ctx context.Context) (map[string]*Datasto
 	return dsURLInfoMap, nil
 }
 
+func (dc *Datacenter) GetAllHosts(ctx context.Context) ([]types.ManagedObjectReference, error) {
+	finder := getFinder(dc)
+	hostSystems, err := finder.HostSystemList(ctx, "*")
+	if err != nil {
+		klog.Errorf("Failed to get all hostSystems. err: %+v", err)
+		return nil, err
+	}
+	var hostMors []types.ManagedObjectReference
+	for _, hs := range hostSystems {
+		hostMors = append(hostMors, hs.Reference())
+	}
+	return hostMors, nil
+}
+
 // GetDatastoreByPath gets the Datastore object from the given vmDiskPath
 func (dc *Datacenter) GetDatastoreByPath(ctx context.Context, vmDiskPath string) (*Datastore, error) {
 	datastorePathObj := new(object.DatastorePath)

--- a/pkg/cloudprovider/providers/vsphere/vclib/datastore.go
+++ b/pkg/cloudprovider/providers/vsphere/vclib/datastore.go
@@ -85,3 +85,19 @@ func (ds *Datastore) IsCompatibleWithStoragePolicy(ctx context.Context, storageP
 	}
 	return pbmClient.IsDatastoreCompatible(ctx, storagePolicyID, ds)
 }
+
+// Get the host names mounted on given datastore
+func (ds *Datastore) GetDatastoreHostMounts(ctx context.Context) ([]types.ManagedObjectReference, error) {
+	var dsMo mo.Datastore
+	pc := property.DefaultCollector(ds.Client())
+	err := pc.RetrieveOne(ctx, ds.Datastore.Reference(), []string{"host"}, &dsMo)
+	if err != nil {
+		klog.Error("Failed to retrieve datastore host mount property. err: %v", err)
+		return nil, err
+	}
+	hosts := make([]types.ManagedObjectReference, 0)
+	for _, dsHostMount := range dsMo.Host {
+		hosts = append(hosts, dsHostMount.Key)
+	}
+	return hosts, nil
+}

--- a/pkg/cloudprovider/providers/vsphere/vclib/volumeoptions.go
+++ b/pkg/cloudprovider/providers/vsphere/vclib/volumeoptions.go
@@ -33,6 +33,7 @@ type VolumeOptions struct {
 	StoragePolicyName      string
 	StoragePolicyID        string
 	SCSIControllerType     string
+	Zone                   []string
 }
 
 var (

--- a/pkg/cloudprovider/providers/vsphere/vsphere.go
+++ b/pkg/cloudprovider/providers/vsphere/vsphere.go
@@ -73,14 +73,14 @@ var cleanUpDummyVMLock sync.RWMutex
 const (
 	MissingUsernameErrMsg = "Username is missing"
 	MissingPasswordErrMsg = "Password is missing"
-	NoZoneTagInVCErrMsg = "No zone tags found in vCenter"
+	NoZoneTagInVCErrMsg   = "No zone tags found in vCenter"
 )
 
 // Error constants
 var (
 	ErrUsernameMissing = errors.New(MissingUsernameErrMsg)
 	ErrPasswordMissing = errors.New(MissingPasswordErrMsg)
-	NoZoneTagInVC = errors.New(NoZoneTagInVCErrMsg)
+	NoZoneTagInVC      = errors.New(NoZoneTagInVCErrMsg)
 )
 
 var _ cloudprovider.Interface = (*VSphere)(nil)
@@ -521,6 +521,9 @@ func buildVSphereFromConfig(cfg VSphereConfig) (*VSphere, error) {
 			vsphereInstanceMap: vsphereInstanceMap,
 			nodeInfoMap:        make(map[string]*NodeInfo),
 			registeredNodes:    make(map[string]*v1.Node),
+			zoneInfoMap:        make(map[string]*cloudprovider.Zone),
+			zoneCategoryName:   cfg.Labels.Zone,
+			regionCategoryName: cfg.Labels.Region,
 		},
 		isSecretInfoProvided: isSecretInfoProvided,
 		cfg:                  &cfg,
@@ -1144,6 +1147,7 @@ func (vs *VSphere) CreateVolume(volumeOptions *vclib.VolumeOptions) (canonicalVo
 	klog.V(1).Infof("Starting to create a vSphere volume with volumeOptions: %+v", volumeOptions)
 	createVolumeInternal := func(volumeOptions *vclib.VolumeOptions) (canonicalVolumePath string, err error) {
 		var datastore string
+		var dsList []*vclib.DatastoreInfo
 		// If datastore not specified, then use default datastore
 		if volumeOptions.Datastore == "" {
 			datastore = vs.cfg.Workspace.DefaultDatastore
@@ -1164,6 +1168,27 @@ func (vs *VSphere) CreateVolume(volumeOptions *vclib.VolumeOptions) (canonicalVo
 		}
 		var vmOptions *vclib.VMOptions
 		if volumeOptions.VSANStorageProfileData != "" || volumeOptions.StoragePolicyName != "" {
+			// If datastore and zone are specified, first validate if the datastore is in the provided zone.
+			if len(volumeOptions.Zone) != 0 && volumeOptions.Datastore != "" {
+				klog.V(4).Infof("Specified zone : %s, datastore : %s", volumeOptions.Zone, volumeOptions.Datastore)
+				dsList, err = getDatastoresForZone(ctx, dc, vs.nodeManager, volumeOptions.Zone)
+				if err != nil {
+					return "", err
+				}
+
+				// Validate if the datastore provided belongs to the zone. If not, fail the operation.
+				found := false
+				for _, ds := range dsList {
+					if ds.Info.Name == volumeOptions.Datastore {
+						found = true
+						break
+					}
+				}
+				if !found {
+					msg := fmt.Sprintf("The specified datastore %s does not match the provided availability zones : %s", volumeOptions.Datastore, volumeOptions.Zone)
+					return "", errors.New(msg)
+				}
+			}
 			// Acquire a read lock to ensure multiple PVC requests can be processed simultaneously.
 			cleanUpDummyVMLock.RLock()
 			defer cleanUpDummyVMLock.RUnlock()
@@ -1183,29 +1208,84 @@ func (vs *VSphere) CreateVolume(volumeOptions *vclib.VolumeOptions) (canonicalVo
 			}
 		}
 		if volumeOptions.StoragePolicyName != "" && volumeOptions.Datastore == "" {
-			datastore, err = getPbmCompatibleDatastore(ctx, dc, volumeOptions.StoragePolicyName, vs.nodeManager)
+			if len(volumeOptions.Zone) == 0 {
+				klog.V(4).Infof("Selecting a shared datastore as per the storage policy %s", volumeOptions.StoragePolicyName)
+				datastore, err = getPbmCompatibleDatastore(ctx, dc, volumeOptions.StoragePolicyName, vs.nodeManager)
+			} else {
+				// If zone is specified, first get the datastores in the zone.
+				dsList, err = getDatastoresForZone(ctx, dc, vs.nodeManager, volumeOptions.Zone)
+
+				// If unable to get any datastore, fail the operation.
+				if len(dsList) == 0 {
+					err := fmt.Errorf("Failed to find a shared datastore matching zone %s", volumeOptions.Zone)
+					klog.Error(err)
+					return "", err
+				}
+
+				klog.V(4).Infof("Specified zone : %s. Picking a datastore as per the storage policy %s among the zoned datastores : %s", volumeOptions.Zone,
+					volumeOptions.StoragePolicyName, dsList)
+				// Among the compatible datastores, select the one based on the maximum free space.
+				datastore, err = getPbmCompatibleZonedDatastore(ctx, dc, volumeOptions.StoragePolicyName, dsList)
+			}
+			klog.V(1).Infof("Datastore selected as per policy : %s", datastore)
 			if err != nil {
 				klog.Errorf("Failed to get pbm compatible datastore with storagePolicy: %s. err: %+v", volumeOptions.StoragePolicyName, err)
 				return "", err
 			}
 		} else {
-			// Since no storage policy is specified but datastore is specified, check
-			// if the given datastore is a shared datastore across all node VMs.
-			sharedDsList, err := getSharedDatastoresInK8SCluster(ctx, dc, vs.nodeManager)
-			if err != nil {
-				klog.Errorf("Failed to get shared datastore: %+v", err)
-				return "", err
-			}
-			found := false
-			for _, sharedDs := range sharedDsList {
-				if datastore == sharedDs.Info.Name {
-					found = true
-					break
+			// If zone is specified, pick the datastore in the zone with maximum free space within the zone.
+			if volumeOptions.Datastore == "" && len(volumeOptions.Zone) != 0 {
+				klog.V(4).Infof("Specified zone : %s", volumeOptions.Zone)
+				dsList, err = getDatastoresForZone(ctx, dc, vs.nodeManager, volumeOptions.Zone)
+
+				// If unable to get any datastore, fail the operation
+				if len(dsList) == 0 {
+					err := fmt.Errorf("Failed to find a shared datastore matching zone %s", volumeOptions.Zone)
+					klog.Error(err)
+					return "", err
 				}
-			}
-			if !found {
-				msg := fmt.Sprintf("The specified datastore %s is not a shared datastore across node VMs", datastore)
-				return "", errors.New(msg)
+
+				if err != nil {
+					return "", err
+				}
+				datastore, err = getMostFreeDatastoreName(ctx, nil, dsList)
+				if err != nil {
+					klog.Errorf("Failed to get shared datastore: %+v", err)
+					return "", err
+				}
+				klog.V(1).Infof("Specified zone : %s. Selected datastore : %s", volumeOptions.StoragePolicyName, datastore)
+			} else {
+				var sharedDsList []*vclib.DatastoreInfo
+				if len(volumeOptions.Zone) == 0 {
+					// If zone is not provided, get the shared datastore across all node VMs.
+					klog.V(4).Infof("Validating if datastore %s is shared across all node VMs", datastore)
+					var err error
+					sharedDsList, err = getSharedDatastoresInK8SCluster(ctx, dc, vs.nodeManager)
+					if err != nil {
+						klog.Errorf("Failed to get shared datastore: %+v", err)
+						return "", err
+					}
+				} else {
+					// If zone is provided, get the shared datastores in that zone.
+					klog.V(4).Infof("Validating if datastore %s is in zone %s ", datastore, volumeOptions.Zone)
+					sharedDsList, err = getDatastoresForZone(ctx, dc, vs.nodeManager, volumeOptions.Zone)
+					if err != nil {
+						return "", err
+					}
+				}
+				found := false
+				// Check if the selected datastore belongs to the list of shared datastores computed.
+				for _, sharedDs := range sharedDsList {
+					if datastore == sharedDs.Info.Name {
+						klog.V(4).Infof("Datastore validation succeeded")
+						found = true
+						break
+					}
+				}
+				if !found {
+					msg := fmt.Sprintf("The specified datastore %s is not a shared datastore across node VMs or does not match the provided availability zones : %s", datastore, volumeOptions.Zone)
+					return "", errors.New(msg)
+				}
 			}
 		}
 		ds, err := dc.GetDatastoreByName(ctx, datastore)

--- a/pkg/cloudprovider/providers/vsphere/vsphere_util.go
+++ b/pkg/cloudprovider/providers/vsphere/vsphere_util.go
@@ -27,8 +27,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/property"
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+	cloudprovider "k8s.io/cloud-provider"
 	"k8s.io/klog"
 
 	"k8s.io/api/core/v1"
@@ -233,6 +237,97 @@ func getPbmCompatibleDatastore(ctx context.Context, dc *vclib.Datacenter, storag
 	if err != nil {
 		klog.Errorf("Failed to get compatible datastores from datastores : %+v with storagePolicy: %s. err: %+v",
 			sharedDs, storagePolicyID, err)
+		return "", err
+	}
+	klog.V(9).Infof("compatibleDatastores : %+v", compatibleDatastores)
+	datastore, err := getMostFreeDatastoreName(ctx, dc.Client(), compatibleDatastores)
+	if err != nil {
+		klog.Errorf("Failed to get most free datastore from compatible datastores: %+v. err: %+v", compatibleDatastores, err)
+		return "", err
+	}
+	klog.V(4).Infof("Most free datastore : %+s", datastore)
+	return datastore, err
+}
+
+func getDatastoresForZone(ctx context.Context, dc *vclib.Datacenter, nodeManager *NodeManager, selectedZones []string) ([]*vclib.DatastoreInfo, error) {
+
+	var sharedDatastores []*vclib.DatastoreInfo
+
+	// Create cloudprovider.Zone type from selectedZones
+	var cpZones []cloudprovider.Zone
+	for _, selectedZone := range selectedZones {
+		var cpZone cloudprovider.Zone
+		cpZone.FailureDomain = selectedZone
+		cpZones = append(cpZones, cpZone)
+	}
+
+	for _, cpZone := range cpZones {
+		var sharedDatastoresPerZone []*vclib.DatastoreInfo
+		hosts, err := nodeManager.GetHostsInZone(ctx, cpZone)
+		if err != nil {
+			return nil, err
+		}
+		klog.V(4).Infof("Hosts in zone %s : %s", cpZone.FailureDomain, hosts)
+
+		for _, host := range hosts {
+			var hostSystemMo mo.HostSystem
+			host.Properties(ctx, host.Reference(), []string{"datastore"}, &hostSystemMo)
+			klog.V(4).Infof("Datastores mounted on host %s : %s", hostSystemMo, hostSystemMo.Datastore)
+			var dsRefList []types.ManagedObjectReference
+			for _, dsRef := range hostSystemMo.Datastore {
+				dsRefList = append(dsRefList, dsRef)
+			}
+
+			var dsMoList []mo.Datastore
+			pc := property.DefaultCollector(host.Client())
+			properties := []string{DatastoreInfoProperty}
+			err = pc.Retrieve(ctx, dsRefList, properties, &dsMoList)
+			if err != nil {
+				klog.Errorf("Failed to get Datastore managed objects from datastore objects."+
+					" dsObjList: %+v, properties: %+v, err: %v", dsRefList, properties, err)
+				return nil, err
+			}
+			klog.V(7).Infof("Datastore mo details: %+v", dsMoList)
+
+			var dsObjList []*vclib.DatastoreInfo
+			for _, dsMo := range dsMoList {
+				dsObjList = append(dsObjList,
+					&vclib.DatastoreInfo{
+						&vclib.Datastore{object.NewDatastore(host.Client(), dsMo.Reference()),
+							nil},
+						dsMo.Info.GetDatastoreInfo()})
+			}
+
+			klog.V(7).Infof("DatastoreInfo details : %s", dsObjList)
+
+			if len(sharedDatastoresPerZone) == 0 {
+				sharedDatastoresPerZone = dsObjList
+			} else {
+				sharedDatastoresPerZone = intersect(sharedDatastoresPerZone, dsObjList)
+			}
+			klog.V(7).Infof("Shared datastore list now : %s", sharedDatastoresPerZone)
+		}
+		klog.V(4).Infof("Shared datastore per zone %s is %s", cpZone, sharedDatastoresPerZone)
+		sharedDatastores = append(sharedDatastores, sharedDatastoresPerZone...)
+	}
+	klog.V(1).Infof("Returning selected datastores : %s", sharedDatastores)
+	return sharedDatastores, nil
+}
+
+func getPbmCompatibleZonedDatastore(ctx context.Context, dc *vclib.Datacenter, storagePolicyName string, zonedDatastores []*vclib.DatastoreInfo) (string, error) {
+	pbmClient, err := vclib.NewPbmClient(ctx, dc.Client())
+	if err != nil {
+		return "", err
+	}
+	storagePolicyID, err := pbmClient.ProfileIDByName(ctx, storagePolicyName)
+	if err != nil {
+		klog.Errorf("Failed to get Profile ID by name: %s. err: %+v", storagePolicyName, err)
+		return "", err
+	}
+	compatibleDatastores, _, err := pbmClient.GetCompatibleDatastores(ctx, dc, storagePolicyID, zonedDatastores)
+	if err != nil {
+		klog.Errorf("Failed to get compatible datastores from datastores : %+v with storagePolicy: %s. err: %+v",
+			zonedDatastores, storagePolicyID, err)
 		return "", err
 	}
 	klog.V(9).Infof("compatibleDatastores : %+v", compatibleDatastores)

--- a/pkg/volume/vsphere_volume/vsphere_volume.go
+++ b/pkg/volume/vsphere_volume/vsphere_volume.go
@@ -161,7 +161,7 @@ func (plugin *vsphereVolumePlugin) ConstructVolumeSpec(volumeName, mountPath str
 // Abstract interface to disk operations.
 type vdManager interface {
 	// Creates a volume
-	CreateVolume(provisioner *vsphereVolumeProvisioner) (volSpec *VolumeSpec, err error)
+	CreateVolume(provisioner *vsphereVolumeProvisioner, selectedZone []string) (volSpec *VolumeSpec, err error)
 	// Deletes a volume
 	DeleteVolume(deleter *vsphereVolumeDeleter) error
 }
@@ -358,8 +358,10 @@ func (v *vsphereVolumeProvisioner) Provision(selectedNode *v1.Node, allowedTopol
 	if !util.AccessModesContainedInAll(v.plugin.GetAccessModes(), v.options.PVC.Spec.AccessModes) {
 		return nil, fmt.Errorf("invalid AccessModes %v: only AccessModes %v are supported", v.options.PVC.Spec.AccessModes, v.plugin.GetAccessModes())
 	}
-
-	volSpec, err := v.manager.CreateVolume(v)
+	klog.V(1).Infof("Provision with allowedTopologies : %s", allowedTopologies)
+	selectedZones, err := util.ZonesFromAllowedTopologies(allowedTopologies)
+	klog.V(4).Infof("Selected zones for volume : %s", selectedZones)
+	volSpec, err := v.manager.CreateVolume(v, selectedZones.List())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/volume/vsphere_volume/vsphere_volume_util.go
+++ b/pkg/volume/vsphere_volume/vsphere_volume_util.go
@@ -83,7 +83,7 @@ func verifyDevicePath(path string) (string, error) {
 }
 
 // CreateVolume creates a vSphere volume.
-func (util *VsphereDiskUtil) CreateVolume(v *vsphereVolumeProvisioner) (volSpec *VolumeSpec, err error) {
+func (util *VsphereDiskUtil) CreateVolume(v *vsphereVolumeProvisioner, selectedZone []string) (volSpec *VolumeSpec, err error) {
 	var fstype string
 	cloud, err := getCloudProvider(v.plugin.host.GetCloudProvider())
 	if err != nil {
@@ -104,6 +104,7 @@ func (util *VsphereDiskUtil) CreateVolume(v *vsphereVolumeProvisioner) (volSpec 
 		Name:       name,
 	}
 
+	volumeOptions.Zone = selectedZone
 	// Apply Parameters (case-insensitive). We leave validation of
 	// the values to the cloud provider.
 	for parameter, value := range v.options.Parameters {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Currently vsphere cloud provider (VCP) insists on provisioning a volume only on a globally shared datastore. Hence, in a zoned environment, even in presence of a shared datastore within a specific zone, the volume provisioning can fail if that datastore is not shared across all the zones hosting kubernetes nodes. This change fixes this issue by considering the zone information provided in allowedTopologies for selection of the datastore. If allowedTopologies is not provided, the current behaviour is retained as-is.
Further, after a volume is created on vSphere, the zone label does not get applied on it today. Without this information on the volume, a pod that uses this volume could get scheduled to a different zone where this volume is not visible/accessible. This issue can be solved by just labeling the volume with the zone information. This PR computes the zone of a volume in the PersistentVolumeLabel admission controller since vsphere is still an in-tree cloud provider and the out-of-tree plugin in still the works.
**Which issue(s) this PR fixes**:
Fixes #67703

**Does this PR introduce a user-facing change?**:
Yes
```
This change ensures that volumes get provisioned based on the zone information provided in allowedTopologies and gets appropriate label.

Storage class spec:
kind: StorageClass
apiVersion: storage.k8s.io/v1
metadata:
  name: fastpolicy1
provisioner: kubernetes.io/vsphere-volume
parameters:
    diskformat: zeroedthick
    storagePolicyName: vSAN Default Storage Policy
allowedTopologies:
- matchLabelExpressions:
  - key: failure-domain.beta.kubernetes.io/zone
    values:
    - zone1

After PV creation:
[container]:/pks> kubectl get pv --show-labels
NAME   CAPACITY   ACCESSMODES   RECLAIMPOLICY   STATUS   CLAIM   STORAGECLASS   REASON  
 AGE   LABELS
pvc-ba4b80cc-100f-11e9-9143-005056804cc9   1Gi   RWO   Delete   Bound   default/pvcsc-1-policy 
  fastpolicy1   2s   failure-domain.beta.kubernetes.io/region=EMEA,failure-domain.beta.kubernetes.io/zone=zone1

New zone tests:
http://blr-dbc505.eng.vmware.com/sandeepsunny/zone-tests.log
Ran 15 of 2135 Specs in 1203.660 seconds
SUCCESS! -- 15 Passed | 0 Failed | 0 Pending | 2120 Skipped PASS

Regression test:
http://cna-storage-jenkins.eng.vmware.com/job/Run-k8s-test-latest/76/consoleFull
Ran 35 of 2119 Specs in 4579.419 seconds
FAIL! -- 34 Passed | 1 Failed | 0 Pending | 2084 Skipped --- FAIL: TestE2E (4579.74s)
The single failure is a test issue.
```